### PR TITLE
blog: 647 mil documentos después — conversión masiva DOF a Markdown

### DIFF
--- a/src/content/blog/es/2026/04/647-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
+++ b/src/content/blog/es/2026/04/647-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
@@ -145,9 +145,40 @@ La mayoría son documentos cortos — avisos, nombramientos, fe de erratas. Pero
 
 5. **Procesamiento paralelo es indispensable.** A 8.7 archivos/segundo con 4 workers, la conversión tomó ~20 horas. Secuencialmente habría tardado más de 3 días.
 
-## ¿Qué sigue?
+## ¿Qué sigue? Los PDFs escaneados
 
-Los 647,017 archivos Markdown están listos. El siguiente paso en el pipeline es la generación de embeddings para construir el sistema de búsqueda semántica. Pero esa es una historia para otro post.
+Los 647,017 archivos Markdown están listos. Pero aquí viene la parte que no esperábamos.
+
+El DOF no siempre publicó archivos .doc individuales. Antes de 1999, las ediciones solo existían en papel, y el sitio del DOF las digitalizó como PDFs escaneados — imágenes de cada página, sin texto extraíble. Y cuando decimos "antes de 1999", hablamos de **décadas**: el sitio tiene PDFs desde al menos 1990, con algunas ediciones aisladas de 1920 y 1922.
+
+¿La escala real? Analizamos lo que tenemos descargado y lo que falta:
+
+| Periodo | Tipo de PDF | Texto extraíble |
+|---------|------------|-----------------|
+| 1920-1922 | Ediciones aisladas | No |
+| 1990-2004 | Escaneado (imágenes) | **No** |
+| 2005-2008 | Escaneado | **No** |
+| 2009-2011 | Transición (mixto) | Parcial |
+| 2012-2025 | Mayormente digital | Sí |
+
+Hemos descargado 6,079 ediciones (2002-2025, 102 GB), pero **todavía faltan los PDFs de 1990-2001** — unos 12 años, aproximadamente 3,000 ediciones más. Estimamos entre **650,000 y 850,000 páginas escaneadas** en total. Es decir: décadas de leyes, decretos, tarifas arancelarias, avisos y resoluciones que actualmente solo existen como imágenes inaccesibles.
+
+### OCR con modelos de visión-lenguaje
+
+La buena noticia es que los modelos de OCR basados en VLMs (Vision-Language Models) han avanzado enormemente. Referencias recientes como el [trabajo de Daniel van Stren](https://danielvanstrien.xyz/posts/2026/re-ocr-collections/) y los [benchmarks de LightOn](https://lighton.ai/lighton-blogs/open-source-lightonocr-2-just-outscored-claude-gpt-5-qwen3-mistral-and-mathpix-at-table-extraction) muestran que modelos como **LightOnOCR-2** (1B parámetros, Apache 2.0) pueden procesar documentos escaneados a ~$0.002 por página con calidad profesional — superando incluso a GPT-5 mini y Claude Sonnet 4.6 en extracción de tablas.
+
+El plan:
+
+1. **Descargar** los PDFs faltantes (1990-2001)
+2. **Ejecutar OCR** con modelos VLM via Hugging Face Jobs (GPU en la nube)
+3. **Generar Markdown** limpio a partir de las imágenes escaneadas
+4. **Integrar** con los 647,017 archivos .md ya existentes
+
+Costo estimado: **~$800-1,500 USD** para toda la colección. Sí, menos de lo que cuesta un café por día durante un año para digitalizar décadas del registro oficial de México.
+
+Más allá del RAG, esto tiene un valor enorme como patrimonio documental. Cualquiera que haya intentado buscar una ley o decreto de los 90s en el sitio del DOF sabe la frustración: PDFs escaneados que no se pueden buscar, páginas que hay que hojear una por una. Digitalizar esto es un servicio público.
+
+Esa es una historia para otro post. Stay tuned :-p
 
 El código de conversión está disponible en nuestro [repositorio de GitHub](https://github.com/CodeandoGuadalajara/dof-rag).
 

--- a/src/content/blog/es/2026/04/647-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
+++ b/src/content/blog/es/2026/04/647-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
@@ -1,0 +1,156 @@
+---
+title: '647 mil documentos después: cómo convertimos TODO el DOF a Markdown'
+date: 2026-04-20T06:00:00.000Z
+author: Equipo DOF-RAG
+description: >-
+  De 647,017 archivos .doc del Diario Oficial de la Federación a Markdown
+  limpio: la historia completa de nuestra conversión masiva, los obstáculos
+  que encontramos y cómo herramientas como catdoc y python-docx nos
+  salvaron en la recta final.
+tags:
+  - DOF-RAG
+  - conversión de documentos
+  - Markdown
+  - LibreOffice
+  - Pandoc
+  - catdoc
+featured: true
+---
+
+# 647,017 documentos: la conversión masiva que sí terminó
+
+Si [ya platicamos](https://codeandoguadalajara.github.io/dof-rag-website/es/blog/2025/11/cuatro-pasos-para-domar-el-dof-conversin-limpieza-anlisis-y-estructura/) de nuestro pipeline de procesamiento —la versión elegante con sus cuatro pasos bien definidos— ahora toca hablar de la versión real: la que convirtió **todos** los archivos .doc del DOF. Sin excepción. Sin "ya quedan unos pocos pero no pasa nada".
+
+Spoiler: sí pasaba. Y la solución fue más creativa de lo que esperábamos.
+
+## El número: 647,017
+
+Ese es el total de archivos .doc que tiene el Diario Oficial de la Federación desde 1999 hasta 2025. Veintisiete años de documentos gubernamentales: leyes, decretos, avisos, convocatorias, resoluciones... todo lo que el gobierno publica oficialmente, en formato Word binario.
+
+El directorio fuente pesa **71 GB**. Y necesitábamos convertir cada uno de esos archivos a Markdown limpio para poder generar embeddings y construir nuestro sistema RAG.
+
+## El pipeline: LibreOffice + pandoc
+
+Nuestro `convert_doc_to_md.py` usa un flujo de dos pasos:
+
+```
+.doc → [LibreOffice headless] → .docx → [pandoc + filtro Lua] → .md
+```
+
+- **LibreOffice** convierte el .doc binario a .docx (XML moderno)
+- **pandoc** con nuestro filtro Lua personalizado (`dof_headers.lua`) convierte el .docx a Markdown, preservando la estructura de encabezados del DOF
+
+La configuración: 4 workers paralelos, timeout de 600 segundos por archivo, hasta 3 reintentos.
+
+### Los números del bulk
+
+Corrimos la conversión masiva con 4 workers y estos fueron los resultados:
+
+| Métrica | Valor |
+|---------|-------|
+| Archivos procesados | 647,017 |
+| Exitosos | 646,986 (99.995%) |
+| Fallidos | 31 (0.005%) |
+| Velocidad promedio | ~8.7 archivos/segundo |
+| Duración del bulk | ~20 horas |
+| Tamaño .doc original | 71 GB |
+| Tamaño .md resultante | 33 GB |
+
+El 99.995% de cobertura es excelente. Pero esos 31 archivos... ahí estaba el problema.
+
+## Los 31 rebeldes
+
+LibreOffice simplemente no podía con ellos. Dos tipos de falla:
+
+- **Timeout (26 archivos):** LibreOffice se quedaba colgado procesándolos. Ni 600 segundos × 3 reintentos fueron suficientes. Estos archivos son documentos extremadamente largos — tarifas arancelarias completas, listados interminables, documentos con cientos de miles de líneas.
+- **Formato no reconocido (5 archivos):** LibreOffice simplemente los rechazaba. "No es un documento de Word válido", decía.
+
+El problema: cada intento de reintento tomaba 30 minutos por archivo (timeout × reintentos). Estábamos gastando **15 horas** en 31 archivos que no avanzaban. Algo tenía que cambiar.
+
+## La solución alternativa: herramientas de nicho
+
+Analizamos los archivos fallidos y descubrimos que no todos eran iguales. Usamos el comando `file` de Linux para ver qué había realmente detrás de esas extensiones .doc:
+
+### Descubrimiento 1: archivos .doc binarios (OLE)
+
+La mayoría (26 de 31) eran archivos .doc legítimos en formato OLE (Word 97-2003). LibreOffice simplemente se ahogaba con su tamaño o complejidad. Pero ahí estaba **`catdoc`**, una herramienta minimalista que extrae texto directamente del formato binario sin intentar renderizar nada.
+
+```bash
+catdoc archivo.doc > archivo.md
+```
+
+¿El resultado? Extrajo texto limpio de los 26 archivos en menos de un segundo cada uno. Sin timeouts. Sin drama. Uno de ellos tenía **303,380 líneas** y 5.9 MB de texto. `catdoc` lo procesó instantáneamente.
+
+### Descubrimiento 2: archivos .doc que en realidad son .docx
+
+Los 5 restantes tenían algo peculiar: sus primeros bytes eran `PK`, la firma de un archivo ZIP. En otras palabras, eran archivos .docx (formato Office 2007+) disfrazados con extensión .doc. LibreOffice los rechazaba porque esperaba formato binario OLE, no un ZIP.
+
+Para estos usamos **`python-docx`**, que maneja perfectamente el formato Office Open XML:
+
+```python
+from docx import Document
+
+doc = Document("archivo.doc")  # En realidad es .docx
+for paragraph in doc.paragraphs:
+    print(paragraph.text)
+```
+
+### Resultado final
+
+| Método | Archivos | Resultado |
+|--------|----------|-----------|
+| LibreOffice + pandoc | 646,986 | ✅ Exitoso |
+| `catdoc` | 25 | ✅ Exitoso |
+| `python-docx` | 5 | ✅ Exitoso |
+| **Total** | **647,017** | **100% convertido** |
+
+## Distribución: ¿cuánto documento por año?
+
+Una curiosidad que descubrimos al ver los resultados: el DOF no publica la misma cantidad todos los años.
+
+| Año | Documentos | Observación |
+|-----|-----------|-------------|
+| 2014 | 31,620 | Año pico |
+| 2012 | 30,012 | |
+| 2013 | 30,582 | |
+| 2011 | 29,623 | |
+| 2020 | 16,733 | Menor (pandemia) |
+| 2025 | 15,643 | Datos parciales |
+
+El periodo 2011-2014 fue la era dorada de la publicación en el DOF. Desde entonces, la tendencia va a la baja. Curioso.
+
+## Distribución de tamaños
+
+¿Qué tan grandes son los archivos Markdown resultantes?
+
+| Categoría | Tamaño | Cantidad | % del total |
+|-----------|--------|----------|-------------|
+| Pequeños (1-10 KB) | El aviso típico | 461,528 | 71.3% |
+| Medianos (10-100 KB) | Documentos normales | 128,640 | 19.9% |
+| Grandes (100 KB-1 MB) | Documentos extensos | 33,062 | 5.1% |
+| Muy grandes (>1 MB) | Tarifas, listados | 5,308 | 0.8% |
+| Minúsculos (<1 KB) | Portadas, fe de erratas | 18,479 | 2.9% |
+
+La mayoría son documentos cortos — avisos, nombramientos, fe de erratas. Pero hay un 6% que son documentos serios, y un 0.8% que son verdaderos monstruos.
+
+## Lecciones aprendidas
+
+1. **No dependas de una sola herramienta.** LibreOffice cubre el 99.995%, pero ese 0.005% restante te va a doler si no tienes un plan B. Tener `catdoc` y `python-docx` como respaldo hizo la diferencia entre "casi terminamos" y "100% convertido".
+
+2. **Verifica el formato real, no la extensión.** Que un archivo diga `.doc` no significa que sea .doc. Verificar los magic bytes (`PK` = ZIP, `ÐÏ` = OLE) te ahorra horas de debugging.
+
+3. **El timeout mata la productividad.** Cuando un archivo falla consistentemente, reintentar con el mismo timeout solo desperdicia tiempo. Detectar los archivos problemáticos y cambiar de estrategia es más eficiente.
+
+4. **La reducción de tamaño es significativa.** De 71 GB en .doc a 33 GB en .md: más de la mitad del espacio se ahorró, y el texto es mucho más accesible para procesamiento con IA.
+
+5. **Procesamiento paralelo es indispensable.** A 8.7 archivos/segundo con 4 workers, la conversión tomó ~20 horas. Secuencialmente habría tardado más de 3 días.
+
+## ¿Qué sigue?
+
+Los 647,017 archivos Markdown están listos. El siguiente paso en el pipeline es la generación de embeddings para construir el sistema de búsqueda semántica. Pero esa es una historia para otro post.
+
+El código de conversión está disponible en nuestro [repositorio de GitHub](https://github.com/CodeandoGuadalajara/dof-rag).
+
+---
+
+*Este post es parte de la serie de documentación del proyecto [DOF-RAG](https://github.com/CodeandoGuadalajara/dof-rag), una iniciativa de [Codeando Guadalajara](https://codeandoguadalajara.github.io/) para hacer accesible la información del Diario Oficial de la Federación mediante inteligencia artificial.*

--- a/src/content/blog/es/2026/04/657-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
+++ b/src/content/blog/es/2026/04/657-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md
@@ -1,9 +1,9 @@
 ---
-title: '647 mil documentos después: cómo convertimos TODO el DOF a Markdown'
+title: '657 mil documentos después: cómo convertimos TODO el DOF a Markdown'
 date: 2026-04-20T06:00:00.000Z
 author: Equipo DOF-RAG
 description: >-
-  De 647,017 archivos .doc del Diario Oficial de la Federación a Markdown
+  De 657,867 archivos .doc del Diario Oficial de la Federación a Markdown
   limpio: la historia completa de nuestra conversión masiva, los obstáculos
   que encontramos y cómo herramientas como catdoc y python-docx nos
   salvaron en la recta final.
@@ -17,15 +17,15 @@ tags:
 featured: true
 ---
 
-# 647,017 documentos: la conversión masiva que sí terminó
+# 657,867 documentos: la conversión masiva que sí terminó
 
 Si [ya platicamos](https://codeandoguadalajara.github.io/dof-rag-website/es/blog/2025/11/cuatro-pasos-para-domar-el-dof-conversin-limpieza-anlisis-y-estructura/) de nuestro pipeline de procesamiento —la versión elegante con sus cuatro pasos bien definidos— ahora toca hablar de la versión real: la que convirtió **todos** los archivos .doc del DOF. Sin excepción. Sin "ya quedan unos pocos pero no pasa nada".
 
 Spoiler: sí pasaba. Y la solución fue más creativa de lo que esperábamos.
 
-## El número: 647,017
+## El número: 657,867
 
-Ese es el total de archivos .doc que tiene el Diario Oficial de la Federación desde 1999 hasta 2025. Veintisiete años de documentos gubernamentales: leyes, decretos, avisos, convocatorias, resoluciones... todo lo que el gobierno publica oficialmente, en formato Word binario.
+Ese es el total de archivos .doc que tiene el Diario Oficial de la Federación desde enero de 1999 hasta abril de 2026. Veintisiete años de documentos gubernamentales: leyes, decretos, avisos, convocatorias, resoluciones... todo lo que el gobierno publica oficialmente, en formato Word binario.
 
 El directorio fuente pesa **71 GB**. Y necesitábamos convertir cada uno de esos archivos a Markdown limpio para poder generar embeddings y construir nuestro sistema RAG.
 
@@ -48,44 +48,54 @@ Corrimos la conversión masiva con 4 workers y estos fueron los resultados:
 
 | Métrica | Valor |
 |---------|-------|
-| Archivos procesados | 647,017 |
-| Exitosos | 646,986 (99.995%) |
-| Fallidos | 31 (0.005%) |
-| Velocidad promedio | ~8.7 archivos/segundo |
-| Duración del bulk | ~20 horas |
+| Archivos procesados | 657,867 |
+| Exitosos (LibreOffice + pandoc) | 657,227 (99.90%) |
+| Recuperados (catdoc) | 640 |
+| Fallidos | 0 |
+| Velocidad promedio | ~8 archivos/segundo |
 | Tamaño .doc original | 71 GB |
-| Tamaño .md resultante | 33 GB |
+| Tamaño .md + imágenes | 58 GB |
+| Imágenes extraídas | 90,370 |
 
-El 99.995% de cobertura es excelente. Pero esos 31 archivos... ahí estaba el problema.
+### Cobertura verificada
 
-## Los 31 rebeldes
+Para estar seguros de que no nos faltaba nada, comparamos nuestros archivos .doc contra los 6,079 PDFs completos por edición que tenemos descargados (2002-2025):
 
-LibreOffice simplemente no podía con ellos. Dos tipos de falla:
+- Todos los días laborables con PDF tienen correspondiente .doc
+- 2 fechas históricas faltantes se identificaron y descargaron (2002-01-28: +24 docs, 2005-08-09: +181 docs)
+- 2 ediciones extraordinarias de fin de semana confirmadas como solo-PDF escaneado (no existen versiones Word)
+- Pre-1999: no hay archivos word en el sitio del DOF, solo PDFs escaneados
 
-- **Timeout (26 archivos):** LibreOffice se quedaba colgado procesándolos. Ni 600 segundos × 3 reintentos fueron suficientes. Estos archivos son documentos extremadamente largos — tarifas arancelarias completas, listados interminables, documentos con cientos de miles de líneas.
-- **Formato no reconocido (5 archivos):** LibreOffice simplemente los rechazaba. "No es un documento de Word válido", decía.
+## La batalla de las imágenes
 
-El problema: cada intento de reintento tomaba 30 minutos por archivo (timeout × reintentos). Estábamos gastando **15 horas** en 31 archivos que no avanzaban. Algo tenía que cambiar.
+Un descubrimiento importante durante la conversión: el ~1.7% de los archivos (~10,800) tenían referencias a imágenes rotas. El problema era que pandoc se ejecutó sin `--extract-media`, así que los .md decían `![](media/imagen.png)` pero las imágenes nunca se extrajeron.
 
-## La solución alternativa: herramientas de nicho
+La solución fue agregar `--extract-media` al comando de pandoc y reconvertir esos archivos. Resultado: **90,370 imágenes** extraídas correctamente, que suman ~25 GB adicionales al directorio de salida.
+
+## Los rebeldes: cuando LibreOffice dice que no
+
+LibreOffice cubrió el 99.90% de los archivos. Pero hubo 640 archivos (principalmente AVISOS del sistema SIDOF) que simplemente lo hacían colapsar. Dos tipos de falla:
+
+- **Timeout:** LibreOffice se quedaba colgado procesándolos. Ni 600 segundos × 3 reintentos fueron suficientes.
+- **Formato no reconocido:** LibreOffice los rechazaba.
+
+### La solución alternativa: herramientas de nicho
 
 Analizamos los archivos fallidos y descubrimos que no todos eran iguales. Usamos el comando `file` de Linux para ver qué había realmente detrás de esas extensiones .doc:
 
-### Descubrimiento 1: archivos .doc binarios (OLE)
+#### catdoc: el héroe silencioso
 
-La mayoría (26 de 31) eran archivos .doc legítimos en formato OLE (Word 97-2003). LibreOffice simplemente se ahogaba con su tamaño o complejidad. Pero ahí estaba **`catdoc`**, una herramienta minimalista que extrae texto directamente del formato binario sin intentar renderizar nada.
+La mayoría eran archivos .doc legítimos en formato OLE (Word 97-2003). LibreOffice simplemente se ahogaba con su tamaño o complejidad. Pero ahí estaba **`catdoc`**, una herramienta minimalista que extrae texto directamente del formato binario sin intentar renderizar nada.
 
 ```bash
 catdoc archivo.doc > archivo.md
 ```
 
-¿El resultado? Extrajo texto limpio de los 26 archivos en menos de un segundo cada uno. Sin timeouts. Sin drama. Uno de ellos tenía **303,380 líneas** y 5.9 MB de texto. `catdoc` lo procesó instantáneamente.
+¿El resultado? Extrajo texto limpio de los 640 archivos en menos de un segundo cada uno. Sin timeouts. Sin drama.
 
-### Descubrimiento 2: archivos .doc que en realidad son .docx
+#### python-docx: para los disfrazados
 
-Los 5 restantes tenían algo peculiar: sus primeros bytes eran `PK`, la firma de un archivo ZIP. En otras palabras, eran archivos .docx (formato Office 2007+) disfrazados con extensión .doc. LibreOffice los rechazaba porque esperaba formato binario OLE, no un ZIP.
-
-Para estos usamos **`python-docx`**, que maneja perfectamente el formato Office Open XML:
+Algunos archivos tenían algo peculiar: sus primeros bytes eran `PK`, la firma de un archivo ZIP. En otras palabras, eran archivos .docx (formato Office 2007+) disfrazados con extensión .doc. Para estos usamos **`python-docx`**, que maneja perfectamente el formato Office Open XML:
 
 ```python
 from docx import Document
@@ -99,10 +109,10 @@ for paragraph in doc.paragraphs:
 
 | Método | Archivos | Resultado |
 |--------|----------|-----------|
-| LibreOffice + pandoc | 646,986 | ✅ Exitoso |
-| `catdoc` | 25 | ✅ Exitoso |
-| `python-docx` | 5 | ✅ Exitoso |
-| **Total** | **647,017** | **100% convertido** |
+| LibreOffice + pandoc | 657,227 | ✅ Exitoso |
+| `catdoc` | 640 | ✅ Exitoso |
+| `python-docx` | 1 | ✅ Exitoso |
+| **Total** | **657,867** | **100% convertido** |
 
 ## Distribución: ¿cuánto documento por año?
 
@@ -115,7 +125,7 @@ Una curiosidad que descubrimos al ver los resultados: el DOF no publica la misma
 | 2013 | 30,582 | |
 | 2011 | 29,623 | |
 | 2020 | 16,733 | Menor (pandemia) |
-| 2025 | 15,643 | Datos parciales |
+| 2026 | 5,436 | Datos parciales (ene-abr) |
 
 El periodo 2011-2014 fue la era dorada de la publicación en el DOF. Desde entonces, la tendencia va a la baja. Curioso.
 
@@ -125,29 +135,31 @@ El periodo 2011-2014 fue la era dorada de la publicación en el DOF. Desde enton
 
 | Categoría | Tamaño | Cantidad | % del total |
 |-----------|--------|----------|-------------|
-| Pequeños (1-10 KB) | El aviso típico | 461,528 | 71.3% |
-| Medianos (10-100 KB) | Documentos normales | 128,640 | 19.9% |
-| Grandes (100 KB-1 MB) | Documentos extensos | 33,062 | 5.1% |
-| Muy grandes (>1 MB) | Tarifas, listados | 5,308 | 0.8% |
-| Minúsculos (<1 KB) | Portadas, fe de erratas | 18,479 | 2.9% |
+| Pequeños (1-10 KB) | El aviso típico | ~70% | Mayoría |
+| Medianos (10-100 KB) | Documentos normales | ~20% | |
+| Grandes (100 KB-1 MB) | Documentos extensos | ~5% | |
+| Muy grandes (>1 MB) | Tarifas, listados | ~1% | |
+| Minúsculos (<1 KB) | Portadas, fe de erratas | ~3% | |
 
-La mayoría son documentos cortos — avisos, nombramientos, fe de erratas. Pero hay un 6% que son documentos serios, y un 0.8% que son verdaderos monstruos.
+La mayoría son documentos cortos — avisos, nombramientos, fe de erratas. Pero hay un 6% que son documentos serios, y un 1% que son verdaderos monstruos.
 
 ## Lecciones aprendidas
 
-1. **No dependas de una sola herramienta.** LibreOffice cubre el 99.995%, pero ese 0.005% restante te va a doler si no tienes un plan B. Tener `catdoc` y `python-docx` como respaldo hizo la diferencia entre "casi terminamos" y "100% convertido".
+1. **No dependas de una sola herramienta.** LibreOffice cubre el 99.9%, pero ese 0.1% restante te va a doler si no tienes un plan B. Tener `catdoc` y `python-docx` como respaldo hizo la diferencia entre "casi terminamos" y "100% convertido".
 
 2. **Verifica el formato real, no la extensión.** Que un archivo diga `.doc` no significa que sea .doc. Verificar los magic bytes (`PK` = ZIP, `ÐÏ` = OLE) te ahorra horas de debugging.
 
 3. **El timeout mata la productividad.** Cuando un archivo falla consistentemente, reintentar con el mismo timeout solo desperdicia tiempo. Detectar los archivos problemáticos y cambiar de estrategia es más eficiente.
 
-4. **La reducción de tamaño es significativa.** De 71 GB en .doc a 33 GB en .md: más de la mitad del espacio se ahorró, y el texto es mucho más accesible para procesamiento con IA.
+4. **Las imágenes importan.** El primer run sin `--extract-media` dejó ~10,800 archivos con referencias rotas. Siempre verifica que los outputs tengan todo lo que el contenido referencia.
 
-5. **Procesamiento paralelo es indispensable.** A 8.7 archivos/segundo con 4 workers, la conversión tomó ~20 horas. Secuencialmente habría tardado más de 3 días.
+5. **Verifica contra fuentes externas.** Comparar contra los PDFs completos nos permitió encontrar 2 fechas faltantes que ni sabíamos que teníamos.
+
+6. **Procesamiento paralelo es indispensable.** A ~8 archivos/segundo con 4 workers, la conversión tomó varias horas. Secuencialmente habría tardado días.
 
 ## ¿Qué sigue? Los PDFs escaneados
 
-Los 647,017 archivos Markdown están listos. Pero aquí viene la parte que no esperábamos.
+Los 657,867 archivos Markdown están listos. Pero aquí viene la parte que no esperábamos.
 
 El DOF no siempre publicó archivos .doc individuales. Antes de 1999, las ediciones solo existían en papel, y el sitio del DOF las digitalizó como PDFs escaneados — imágenes de cada página, sin texto extraíble. Y cuando decimos "antes de 1999", hablamos de **décadas**: el sitio tiene PDFs desde al menos 1990, con algunas ediciones aisladas de 1920 y 1922.
 
@@ -172,7 +184,7 @@ El plan:
 1. **Descargar** los PDFs faltantes (1990-2001)
 2. **Ejecutar OCR** con modelos VLM via Hugging Face Jobs (GPU en la nube)
 3. **Generar Markdown** limpio a partir de las imágenes escaneadas
-4. **Integrar** con los 647,017 archivos .md ya existentes
+4. **Integrar** con los 657,867 archivos .md ya existentes
 
 Costo estimado: **~$800-1,500 USD** para toda la colección. Sí, menos de lo que cuesta un café por día durante un año para digitalizar décadas del registro oficial de México.
 


### PR DESCRIPTION
## Nuevo post del blog

Documenta la conversión completa de los 647,017 archivos .doc del DOF a Markdown.

### Contenido
- Pipeline LibreOffice + pandoc (99.995% de cobertura)
- Los 31 archivos rebeldes y cómo se resolvieron con catdoc y python-docx
- Distribución por año (1999-2025) y por tamaño
- Lecciones aprendidas

### Archivo
`src/content/blog/es/2026/04/647-mil-documentos-despues-cmo-convertimos-todo-el-DOF-a-Markdown.md`