### PR TITLE
Replace popular posts sidebar with tag cloud

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -10,7 +10,7 @@
   "footer.email": "Email",
   
   "home.title": "DOF-RAG Blog - Home",
-  "home.popular_posts": "Popular Posts",
+  "home.tags": "Tags",
   "home.subscribe": "Subscribe",
   "home.stay_updated": "Stay updated with the project news",
   "home.recent_posts": "Recent Posts",

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -10,7 +10,7 @@
   "footer.email": "Correo",
   
   "home.title": "DOF-RAG Blog - Inicio",
-  "home.popular_posts": "Posts populares",
+  "home.tags": "Etiquetas",
   "home.subscribe": "Suscríbete",
   "home.stay_updated": "Mantente al día con las novedades del proyecto",
   "home.recent_posts": "Publicaciones recientes",

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import { getLangFromUrl } from '../../i18n/utils.ts';
-import { supportedLanguages, dateFormatOptions, type SupportedLanguage } from '../../i18n/config';
+import { supportedLanguages, type SupportedLanguage } from '../../i18n/config';
 import BlogPostsGrid from '../../components/BlogPostsGrid.astro';
 
 // Obtener el idioma actual de la URL
@@ -31,21 +31,15 @@ const allBlogPosts = await getCollection('blog', ({ data, slug }) => {
   return false;
 });
 
-// Posts populares para el sidebar (podrías tener una lógica diferente para determinar popularidad)
-const popularPosts = allBlogPosts.slice(0, 5);
-
-// Función para preparar el slug (remover prefijo de idioma si existe)
-function prepareSlug(slug: string): string {
-  if (slug.startsWith('en/') || slug.startsWith('es/')) {
-    return slug.substring(3); // Eliminar el prefijo de idioma
+// Extraer tags con conteo de posts
+const tagCounts = new Map<string, number>();
+for (const post of allBlogPosts) {
+  for (const tag of (post.data.tags || [])) {
+    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
   }
-  return slug;
 }
-
-// Obtener posts destacados si existen
-const featuredPosts = allBlogPosts.filter(post => post.data.featured);
-// Si no hay posts destacados, usar los más recientes
-const popularPostsForSidebar = featuredPosts.length > 0 ? featuredPosts : allBlogPosts.slice(0, 3);
+// Ordenar por frecuencia (más usados primero)
+const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
 
 // Add title letters for blur effect
 const titleText = "DOF-RAG";
@@ -82,17 +76,20 @@ export function getStaticPaths() {
   </section>
 
   <div class="grid grid-cols-12 gap-8">
-    <!-- Sidebar con posts populares -->
+    <!-- Sidebar con tags y RSS -->
     <div class="col-span-12 md:col-span-3">
       <div class="sticky top-24">
-        <h2 class="text-xl font-bold mb-6 pb-2 border-b border-[var(--color-border)]">{t('home.popular_posts')}</h2>
-        <ul class="space-y-4">
-          {popularPostsForSidebar.map(post => (
-            <li>
-              <a href={`${import.meta.env.BASE_URL}/${lang}/blog/${prepareSlug(post.slug)}`} class="hover:text-[var(--color-accent)]">{post.data.title}</a>
-            </li>
+        <h2 class="text-xl font-bold mb-6 pb-2 border-b border-[var(--color-border)]">{t('home.tags')}</h2>
+        <div class="flex flex-wrap gap-2">
+          {sortedTags.map(([tag, count]) => (
+            <a
+              href={`${import.meta.env.BASE_URL}/${lang}/tags/${tag}`}
+              class="px-3 py-1 rounded-full text-sm bg-[var(--color-border)] hover:bg-[var(--color-accent)] hover:text-white transition-colors"
+            >
+              #{tag}
+            </a>
           ))}
-        </ul>
+        </div>
 
         <div class="mt-12">
           <h2 class="text-xl font-bold mb-4 pb-2 border-b border-[var(--color-border)]">{t('home.subscribe')}</h2>
@@ -113,7 +110,6 @@ export function getStaticPaths() {
         <span class="gradient-text">{t('home.recent_posts')}</span>
       </h2>
       
-      <!-- Componente de grilla de posts con paginación -->
       <BlogPostsGrid 
         posts={allBlogPosts} 
         lang={lang} 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -76,30 +76,32 @@ export function getStaticPaths() {
   </section>
 
   <div class="grid grid-cols-12 gap-8">
-    <!-- Sidebar con tags y RSS -->
+    <!-- Sidebar con RSS y tags -->
     <div class="col-span-12 md:col-span-3">
       <div class="sticky top-24">
-        <h2 class="text-xl font-bold mb-6 pb-2 border-b border-[var(--color-border)]">{t('home.tags')}</h2>
-        <div class="flex flex-wrap gap-2">
-          {sortedTags.map(([tag, count]) => (
-            <a
-              href={`${import.meta.env.BASE_URL}/${lang}/tags/${tag}`}
-              class="px-3 py-1 rounded-full text-sm bg-[var(--color-border)] hover:bg-[var(--color-accent)] hover:text-white transition-colors"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
-
-        <div class="mt-12">
+        <div>
           <h2 class="text-xl font-bold mb-4 pb-2 border-b border-[var(--color-border)]">{t('home.subscribe')}</h2>
-          <p class="text-[var(--color-muted)] mb-4">{t('home.stay_updated')}</p>
+          <p class="text-[var(--color-muted)] text-sm mb-4">{t('home.stay_updated')}</p>
           <a href={`${import.meta.env.BASE_URL}/rss.xml`} class="inline-block gradient-border px-4 py-2 text-sm font-medium rounded-md hover:opacity-90 flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="currentColor" viewBox="0 0 24 24">
               <path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/>
             </svg>
             <span class="gradient-text">RSS</span>
           </a>
+        </div>
+
+        <div class="mt-8">
+          <h2 class="text-xl font-bold mb-4 pb-2 border-b border-[var(--color-border)]">{t('home.tags')}</h2>
+          <div class="flex flex-wrap gap-1.5">
+            {sortedTags.map(([tag, count]) => (
+              <a
+                href={`${import.meta.env.BASE_URL}/${lang}/tags/${tag}`}
+                class="px-2 py-0.5 rounded-full text-xs bg-[var(--color-border)] hover:bg-[var(--color-accent)] hover:text-white transition-colors"
+              >
+                #{tag}
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The sidebar showed "Popular Posts" but it was just featured/recent posts — no real popularity data.

Replaced with a tag cloud that adds actual navigation value:

- Tags extracted from posts for the current language
- Sorted by frequency (most used first)
- Each tag links to its existing detail page (`/es/tags/Gemini`, etc.)
- Pill-style buttons with hover effect
- Kept the RSS subscribe section below

Also cleaned up dead code: `popularPosts`, `prepareSlug`, `featuredPosts`, unused import.