### PR TITLE
fix: prevent site downtime during deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ permissions:
   pages: write
   id-token: write
 
+# Evitar deploys simultáneos — cancela el anterior si hay uno nuevo
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problema

Al hacer merge de un PR, el sitio se caía durante el deploy (~50s).

## Causa

GitHub Pages estaba configurado como `build_type: 'legacy'`, lo que significa que GitHub intentaba hacer su propio build desde el branch `main` directamente. Al mismo tiempo, el workflow de Actions también hacía build + deploy con `actions/deploy-pages`. Los dos procesos competían y durante la transición el sitio quedaba indisponible.

## Fix

1. **Cambié `build_type` a `'workflow'`** vía API — ahora solo el workflow de Actions maneja el deploy, sin competencia del builder legacy de GitHub.
2. **Agregué `concurrency` group** al workflow — si se lanza un deploy nuevo mientras otro está corriendo, cancela el anterior en lugar de correr ambos en paralelo.

El cambio de build_type ya se aplicó via API. Este PR agrega el concurrency group al workflow.