### PR TITLE
feat(blog): add embedding benchmark post (10 models, quantization)

### DIFF
--- a/public/images/posts/benchmark-embeddings/pareto.svg
+++ b/public/images/posts/benchmark-embeddings/pareto.svg
@@ -1,0 +1,2274 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="432pt" viewBox="0 0 648 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-30T15:37:11.260889</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432 
+L 648 432 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 61.882578 389.2 
+L 539.396038 389.2 
+L 539.396038 42.726328 
+L 61.882578 42.726328 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 115.681818 389.2 
+L 115.681818 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m8963d8996f" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8963d8996f" x="115.681818" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1.7 -->
+      <g transform="translate(107.730256 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 146.07438 389.2 
+L 146.07438 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8963d8996f" x="146.07438" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2.0 -->
+      <g transform="translate(138.122817 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 221.90015 389.2 
+L 221.90015 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8963d8996f" x="221.90015" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 3.0 -->
+      <g transform="translate(213.948588 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 275.69939 389.2 
+L 275.69939 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8963d8996f" x="275.69939" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4.0 -->
+      <g transform="translate(267.747828 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 317.429323 389.2 
+L 317.429323 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8963d8996f" x="317.429323" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 5.0 -->
+      <g transform="translate(309.477761 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 380.352781 389.2 
+L 380.352781 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8963d8996f" x="380.352781" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 7.0 -->
+      <g transform="translate(372.401218 403.797656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1a"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 469.910175 389.2 
+L 469.910175 42.726328 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8963d8996f" x="469.910175" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 11.3 -->
+      <g transform="translate(458.777363 403.797656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <defs>
+       <path id="m336745016b" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m336745016b" x="351.525161" y="389.2" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m336745016b" x="405.324401" y="389.2" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m336745016b" x="427.350931" y="389.2" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- Velocidad de embedding (chunks/s, escala log) -->
+     <g transform="translate(171.183058 418.558281) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-39" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-39"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(60.640625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(122.171875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(149.953125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(211.140625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(266.125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(293.90625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(357.390625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(418.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(482.15625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(513.9375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(577.421875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(638.953125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(670.734375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(732.265625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(829.671875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(893.15625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(954.6875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(1018.171875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1081.65625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1109.4375 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(1172.8125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1236.296875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(1268.078125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1307.09375 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(1362.078125 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(1425.453125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1488.828125 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(1552.203125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1610.109375 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(1662.203125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1695.890625 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(1747.984375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1779.765625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1811.546875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1873.078125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1925.171875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1980.15625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2041.4375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(2069.21875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2130.5 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2162.28125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2190.0625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(2251.25 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(2314.734375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_18">
+      <path d="M 61.882578 372.10937 
+L 539.396038 372.10937 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <defs>
+       <path id="md5a28e4913" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="372.10937" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.350 -->
+      <g transform="translate(26.254453 375.908199) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_20">
+      <path d="M 61.882578 333.267031 
+L 539.396038 333.267031 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="333.267031" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.375 -->
+      <g transform="translate(26.254453 337.065859) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_22">
+      <path d="M 61.882578 294.424691 
+L 539.396038 294.424691 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="294.424691" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.400 -->
+      <g transform="translate(26.254453 298.223519) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_24">
+      <path d="M 61.882578 255.582351 
+L 539.396038 255.582351 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="255.582351" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.425 -->
+      <g transform="translate(26.254453 259.381179) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_26">
+      <path d="M 61.882578 216.740011 
+L 539.396038 216.740011 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="216.740011" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.450 -->
+      <g transform="translate(26.254453 220.538839) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_28">
+      <path d="M 61.882578 177.897671 
+L 539.396038 177.897671 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="177.897671" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.475 -->
+      <g transform="translate(26.254453 181.696499) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_30">
+      <path d="M 61.882578 139.055331 
+L 539.396038 139.055331 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="139.055331" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.500 -->
+      <g transform="translate(26.254453 142.854159) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_32">
+      <path d="M 61.882578 100.212991 
+L 539.396038 100.212991 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="100.212991" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.525 -->
+      <g transform="translate(26.254453 104.011819) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_34">
+      <path d="M 61.882578 61.370651 
+L 539.396038 61.370651 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#md5a28e4913" x="61.882578" y="61.370651" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.550 -->
+      <g transform="translate(26.254453 65.169479) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- MRR (calidad de recuperación) -->
+     <g transform="translate(19.611875 300.511914) rotate(-90) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b5" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+M 2393 5119 
+L 3015 5119 
+L 1997 3944 
+L 1518 3944 
+L 2393 5119 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-30"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(86.28125 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(155.765625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(225.25 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(257.03125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(296.046875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(351.03125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(412.3125 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(440.09375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(467.875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(531.359375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(592.640625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(656.125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(687.90625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(751.390625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(812.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(844.703125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(883.609375 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(945.140625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(1000.125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1063.5 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1126.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(1188.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1229.625 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1290.90625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1345.890625 0)"/>
+      <use xlink:href="#DejaVuSans-b5" transform="translate(1373.671875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1434.859375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1498.234375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_36">
+    <path d="M 469.910175 227.615866 
+L 261.119852 218.293704 
+L 261.119852 139.055331 
+L 239.724046 120.411008 
+L 115.681818 73.8002 
+" clip-path="url(#p80254c822f)" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #999999; stroke-width: 1.2"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 61.882578 389.2 
+L 61.882578 42.726328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 539.396038 389.2 
+L 539.396038 42.726328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 61.882578 389.2 
+L 539.396038 389.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 61.882578 42.726328 
+L 539.396038 42.726328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="PathCollection_1">
+    <path d="M 233.969458 129.21039 
+C 235.891037 129.21039 237.734171 128.446938 239.092933 127.088177 
+C 240.451694 125.729415 241.215146 123.886281 241.215146 121.964702 
+C 241.215146 120.043122 240.451694 118.199988 239.092933 116.841226 
+C 237.734171 115.482465 235.891037 114.719013 233.969458 114.719013 
+C 232.047879 114.719013 230.204744 115.482465 228.845982 116.841226 
+C 227.487221 118.199988 226.723769 120.043122 226.723769 121.964702 
+C 226.723769 123.886281 227.487221 125.729415 228.845982 127.088177 
+C 230.204744 128.446938 232.047879 129.21039 233.969458 129.21039 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 239.724046 127.656696 
+C 241.645625 127.656696 243.48876 126.893245 244.847521 125.534483 
+C 246.206283 124.175722 246.969734 122.332587 246.969734 120.411008 
+C 246.969734 118.489429 246.206283 116.646294 244.847521 115.287533 
+C 243.48876 113.928771 241.645625 113.16532 239.724046 113.16532 
+C 237.802467 113.16532 235.959332 113.928771 234.60057 115.287533 
+C 233.241809 116.646294 232.478357 118.489429 232.478357 120.411008 
+C 232.478357 122.332587 233.241809 124.175722 234.60057 125.534483 
+C 235.959332 126.893245 237.802467 127.656696 239.724046 127.656696 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 202.196747 367.413216 
+C 204.659712 367.413216 207.022131 366.43467 208.76371 364.693091 
+C 210.505289 362.951512 211.483835 360.589093 211.483835 358.126128 
+C 211.483835 355.663164 210.505289 353.300744 208.76371 351.559165 
+C 207.022131 349.817586 204.659712 348.83904 202.196747 348.83904 
+C 199.733783 348.83904 197.371363 349.817586 195.629785 351.559165 
+C 193.888206 353.300744 192.90966 355.663164 192.90966 358.126128 
+C 192.90966 360.589093 193.888206 362.951512 195.629785 364.693091 
+C 197.371363 366.43467 199.733783 367.413216 202.196747 367.413216 
+z
+" clip-path="url(#p80254c822f)" style="fill: #fde725; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 208.997837 202.233989 
+C 210.919416 202.233989 212.762551 201.470537 214.121313 200.111776 
+C 215.480074 198.753014 216.243526 196.90988 216.243526 194.988301 
+C 216.243526 193.066722 215.480074 191.223587 214.121313 189.864825 
+C 212.762551 188.506064 210.919416 187.742612 208.997837 187.742612 
+C 207.076258 187.742612 205.233123 188.506064 203.874362 189.864825 
+C 202.5156 191.223587 201.752149 193.066722 201.752149 194.988301 
+C 201.752149 196.90988 202.5156 198.753014 203.874362 200.111776 
+C 205.233123 201.470537 207.076258 202.233989 208.997837 202.233989 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 469.910175 232.919167 
+C 471.316627 232.919167 472.665664 232.360378 473.660175 231.365866 
+C 474.654687 230.371354 475.213476 229.022318 475.213476 227.615866 
+C 475.213476 226.209414 474.654687 224.860378 473.660175 223.865866 
+C 472.665664 222.871354 471.316627 222.312565 469.910175 222.312565 
+C 468.503723 222.312565 467.154687 222.871354 466.160175 223.865866 
+C 465.165664 224.860378 464.606874 226.209414 464.606874 227.615866 
+C 464.606874 229.022318 465.165664 230.371354 466.160175 231.365866 
+C 467.154687 232.360378 468.503723 232.919167 469.910175 232.919167 
+z
+" clip-path="url(#p80254c822f)" style="fill: #440154; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 255.995988 216.217231 
+C 257.917567 216.217231 259.760702 215.45378 261.119463 214.095018 
+C 262.478225 212.736257 263.241676 210.893122 263.241676 208.971543 
+C 263.241676 207.049964 262.478225 205.206829 261.119463 203.848067 
+C 259.760702 202.489306 257.917567 201.725855 255.995988 201.725855 
+C 254.074409 201.725855 252.231274 202.489306 250.872512 203.848067 
+C 249.513751 205.206829 248.750299 207.049964 248.750299 208.971543 
+C 248.750299 210.893122 249.513751 212.736257 250.872512 214.095018 
+C 252.231274 215.45378 254.074409 216.217231 255.995988 216.217231 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 115.681818 84.868172 
+C 118.617079 84.868172 121.432514 83.701981 123.508056 81.626438 
+C 125.583599 79.550895 126.74979 76.73546 126.74979 73.8002 
+C 126.74979 70.86494 125.583599 68.049505 123.508056 65.973962 
+C 121.432514 63.89842 118.617079 62.732228 115.681818 62.732228 
+C 112.746558 62.732228 109.931123 63.89842 107.855581 65.973962 
+C 105.780038 68.049505 104.613847 70.86494 104.613847 73.8002 
+C 104.613847 76.73546 105.780038 79.550895 107.855581 81.626438 
+C 109.931123 83.701981 112.746558 84.868172 115.681818 84.868172 
+z
+" clip-path="url(#p80254c822f)" style="fill: #fde725; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 255.995988 202.233989 
+C 257.917567 202.233989 259.760702 201.470537 261.119463 200.111776 
+C 262.478225 198.753014 263.241676 196.90988 263.241676 194.988301 
+C 263.241676 193.066722 262.478225 191.223587 261.119463 189.864825 
+C 259.760702 188.506064 257.917567 187.742612 255.995988 187.742612 
+C 254.074409 187.742612 252.231274 188.506064 250.872512 189.864825 
+C 249.513751 191.223587 248.750299 193.066722 248.750299 194.988301 
+C 248.750299 196.90988 249.513751 198.753014 250.872512 200.111776 
+C 252.231274 201.470537 254.074409 202.233989 255.995988 202.233989 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 261.119852 225.539393 
+C 263.041431 225.539393 264.884566 224.775941 266.243328 223.41718 
+C 267.602089 222.058418 268.365541 220.215283 268.365541 218.293704 
+C 268.365541 216.372125 267.602089 214.528991 266.243328 213.170229 
+C 264.884566 211.811468 263.041431 211.048016 261.119852 211.048016 
+C 259.198273 211.048016 257.355139 211.811468 255.996377 213.170229 
+C 254.637615 214.528991 253.874164 216.372125 253.874164 218.293704 
+C 253.874164 220.215283 254.637615 222.058418 255.996377 223.41718 
+C 257.355139 224.775941 259.198273 225.539393 261.119852 225.539393 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+    <path d="M 261.119852 146.301019 
+C 263.041431 146.301019 264.884566 145.537568 266.243328 144.178806 
+C 267.602089 142.820045 268.365541 140.97691 268.365541 139.055331 
+C 268.365541 137.133752 267.602089 135.290617 266.243328 133.931856 
+C 264.884566 132.573094 263.041431 131.809643 261.119852 131.809643 
+C 259.198273 131.809643 257.355139 132.573094 255.996377 133.931856 
+C 254.637615 135.290617 253.874164 137.133752 253.874164 139.055331 
+C 253.874164 140.97691 254.637615 142.820045 255.996377 144.178806 
+C 257.355139 145.537568 259.198273 146.301019 261.119852 146.301019 
+z
+" clip-path="url(#p80254c822f)" style="fill: #414487; fill-opacity: 0.75; stroke: #333333; stroke-opacity: 0.75; stroke-width: 0.8"/>
+   </g>
+   <g id="text_19">
+    <!-- Benchmark de embeddings DOF: velocidad vs calidad -->
+    <g transform="translate(138.989933 21.843047) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-25" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-1d" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-25"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(68.609375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(130.140625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(193.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(248.5 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(311.875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(409.28125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(470.5625 0)"/>
+     <use xlink:href="#DejaVuSans-4e" transform="translate(511.671875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(569.578125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(601.359375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(664.84375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(726.375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(758.15625 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(819.6875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(917.09375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(980.578125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1042.109375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1105.59375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1169.078125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1196.859375 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(1260.234375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1323.71875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1375.8125 0)"/>
+     <use xlink:href="#DejaVuSans-27" transform="translate(1407.59375 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1484.59375 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1563.3125 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(1613.0625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1646.75 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1678.53125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1737.71875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1799.25 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1827.03125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1888.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1943.203125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1970.984375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2034.46875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2095.75 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2159.234375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(2191.015625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2250.203125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2302.296875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2334.078125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2389.0625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2450.34375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2478.125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2505.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2569.390625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2630.671875 0)"/>
+    </g>
+    <!-- (tamaño del punto = parámetros; MacBook Pro M3, MPS) -->
+    <g transform="translate(129.265246 36.726328) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b3" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+M 2063 4281 
+L 1884 4453 
+Q 1816 4516 1764 4545 
+Q 1713 4575 1672 4575 
+Q 1553 4575 1497 4461 
+Q 1441 4347 1434 4091 
+L 1044 4091 
+Q 1050 4513 1209 4742 
+Q 1369 4972 1653 4972 
+Q 1772 4972 1872 4928 
+Q 1972 4884 2088 4781 
+L 2266 4609 
+Q 2334 4547 2386 4517 
+Q 2438 4488 2478 4488 
+Q 2597 4488 2653 4602 
+Q 2709 4716 2716 4972 
+L 3106 4972 
+Q 3100 4550 2940 4320 
+Q 2781 4091 2497 4091 
+Q 2378 4091 2278 4134 
+Q 2178 4178 2063 4281 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-a3" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+M 2290 5119 
+L 2912 5119 
+L 1894 3944 
+L 1415 3944 
+L 2290 5119 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-1e" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-b"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(39.015625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(78.21875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(139.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(236.90625 0)"/>
+     <use xlink:href="#DejaVuSans-b3" transform="translate(298.1875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(361.5625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(422.75 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(454.53125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(518.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(579.546875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(607.328125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(639.109375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(702.59375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(765.96875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(829.34375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(868.546875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(929.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(961.515625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1045.3125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1077.09375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1140.578125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1201.859375 0)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(1242.96875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1304.25 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1401.65625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1463.1875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1502.390625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1541.296875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1602.484375 0)"/>
+     <use xlink:href="#DejaVuSans-1e" transform="translate(1654.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1688.265625 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1720.046875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1806.328125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1867.609375 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1922.59375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1991.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2052.390625 0)"/>
+     <use xlink:href="#DejaVuSans-4e" transform="translate(2113.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2171.484375 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2203.265625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2261.8125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2300.71875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2361.90625 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2393.6875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(2479.96875 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(2543.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2575.375 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2607.15625 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2693.4375 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2753.734375 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(2817.21875 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- pplx-context -->
+    <g style="fill: #444444" transform="translate(165.545083 111.964702) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-5b" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+     <use xlink:href="#DejaVuSans-5b" transform="translate(154.75 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(213.9375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(250.015625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(305 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(366.1875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(429.5625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(468.765625 0)"/>
+     <use xlink:href="#DejaVuSans-5b" transform="translate(528.546875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(587.734375 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- pplx-v1 -->
+    <g style="fill: #444444" transform="translate(249.724046 112.411008) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+     <use xlink:href="#DejaVuSans-5b" transform="translate(154.75 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(213.9375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(247.328125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(306.515625 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- Nemotron-1B -->
+    <g style="fill: #444444" transform="translate(212.196747 374.126128) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(74.8125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(136.34375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(233.75 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(294.9375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(334.140625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(373.046875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(434.234375 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(497.609375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(533.6875 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(597.3125 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- jina-small -->
+    <g style="fill: #444444" transform="translate(155.560181 210.988301) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(55.5625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(118.9375 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(180.21875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(216.296875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(268.390625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(365.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(427.078125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(454.859375 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- jina-nano -->
+    <g style="fill: #444444" transform="translate(416.013769 219.615866) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(55.5625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(118.9375 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(180.21875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(216.296875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(279.671875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(340.953125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(404.328125 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- Octen-0.6B -->
+    <g style="fill: #444444" transform="translate(265.995988 206.971543) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(78.71875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(133.703125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(172.90625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(234.4375 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(297.8125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(333.890625 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(397.515625 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(429.296875 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(492.921875 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- F2LLM-1.7B -->
+    <g style="fill: #444444" transform="translate(125.681818 67.8002) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-29"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(57.515625 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(121.140625 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(176.859375 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(232.578125 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(318.859375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(354.9375 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(418.5625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(450.34375 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(513.96875 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- harrier -->
+    <g style="fill: #444444" transform="translate(215.796769 186.988301) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4b"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(63.375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(124.65625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(164.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(205.125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(232.90625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(294.4375 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- Qwen3-0.6B -->
+    <g style="fill: #444444" transform="translate(269.119852 236.293704) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(78.71875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(160.5 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(222.03125 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(285.40625 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(349.03125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(385.109375 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(448.734375 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(480.515625 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(544.140625 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- F2LLM-0.6B -->
+    <g style="fill: #444444" transform="translate(271.119852 131.055331) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-29"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(57.515625 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(121.140625 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(176.859375 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(232.578125 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(318.859375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(354.9375 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(418.5625 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(450.34375 0)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(513.96875 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 421.196507 384.7 
+L 533.096038 384.7 
+Q 534.896038 384.7 534.896038 382.9 
+L 534.896038 370.299297 
+Q 534.896038 368.499297 533.096038 368.499297 
+L 421.196507 368.499297 
+Q 419.396507 368.499297 419.396507 370.299297 
+L 419.396507 382.9 
+Q 419.396507 384.7 421.196507 384.7 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_37">
+     <path d="M 422.996507 375.787891 
+L 431.996507 375.787891 
+L 440.996507 375.787891 
+" style="fill: none; stroke-dasharray: 4.44,1.92; stroke-dashoffset: 0; stroke: #999999; stroke-width: 1.2"/>
+    </g>
+    <g id="text_30">
+     <!-- Frontera de Pareto -->
+     <g transform="translate(448.196507 378.937891) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-29"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(50.234375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(89.140625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(150.328125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(213.703125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(252.90625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(314.4375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(355.546875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(416.828125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(448.609375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(512.09375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(573.625 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(605.40625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(661.21875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(722.5 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(761.40625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(822.9375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(862.140625 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_8">
+    <path d="M 550.902387 389.2 
+L 568.22607 389.2 
+L 568.22607 42.726328 
+L 550.902387 42.726328 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABgAAAHiCAYAAADyCQwzAAACYklEQVR4nO2d0Y0bMRQDd9dbWkpIv+ksSQeeL+pAYqYAP1Dko2whwd2/7t9/riBP8sOv67re687OyCu4nzs6QA8QPUAOKBjwIKvgvZ96k8NHdCKmevAdqwJ5b+sacA+Q/IVj2REqQBYUWHaAv3CQeIomTFbBd/pjqgfI+69eQXpEf4oGYtqvwEUjTBEyoMA9IPpTtGByVsCAyQeqwkUDTtR1doAeIPEuWqjr+qoY8KC+Kiw7Qg+QfF33v5tqMqEHiGWHuAfIhAfx55zo5xtTZuIxJDvAqkC8MpH+PfCIEGOK6AGiB4jPmjzAmBIqQEwRogeIHiD9Hmgy0m/yAQ/CA/QAGVDgJuMAj4hQAWKKEBUgpogHeESEChBThMQV9A8wRT8/QJMRPUD0AHmvO/skZYqQiRSFB2gyoQLEskP6v767B0g8RQOL1m+yCggvHGTAg/orM56iAZPD/2B2wGSrAllQcJmi75zoIj2AAR4R4ZWJDFyZ/XvQn6J+D6xr4g2fkDFlJhRkB+QVPAMeqAAHRD/fmDIDMX3qnxLcA8I9QPSAB/Qf0ULZtSsYSJEKABUg8S5aOCIVACpABi79AQ/uv9EB/R4YU8SYIu+n34OBPWhPUf8mf0wRD2g/ooWysyq+c6Iq9OA7Jza53oP0c87AEdUr8FsFoQfIhAftCuLPOf1HNHDh1FfFggftCvp/ZfZ3kVcmD6iP6UJV1Cuo98BLn/A3GhLvIk1G+n8EWteIKUL0AIkreJ/6/2TSb3J6wolvdtkBJ1LU/jdLF1LU70FWwURM2xUsxDQ7wxQh7+fu96BcwX+W9I6GnPPTSgAAAABJRU5ErkJggg==" id="image50bb1c6bf4" transform="scale(1 -1) translate(0 -347.04)" x="550.8" y="-42.48" width="17.28" height="347.04"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_38">
+      <defs>
+       <path id="me063284990" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="380.538158" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 800 -->
+      <g transform="translate(575.22607 384.336986) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="326.401647" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 1000 -->
+      <g transform="translate(575.22607 330.200475) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="272.265136" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 1200 -->
+      <g transform="translate(575.22607 276.063964) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="218.128625" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 1400 -->
+      <g transform="translate(575.22607 221.927453) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="163.992113" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 1600 -->
+      <g transform="translate(575.22607 167.790941) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="109.855602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 1800 -->
+      <g transform="translate(575.22607 113.65443) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#me063284990" x="568.22607" y="55.719091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 2000 -->
+      <g transform="translate(575.22607 59.517919) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_38">
+     <!-- Dimensiones del vector -->
+     <g transform="translate(612.274508 274.899102) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-27"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(77 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(104.78125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(202.1875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(263.71875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(327.09375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(379.1875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(406.96875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(468.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(531.53125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(593.0625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(645.15625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(676.9375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(740.421875 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(801.953125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(829.734375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(861.515625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(920.703125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(982.234375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1037.21875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1076.421875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(1137.609375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_9">
+    <path d="M 550.902387 389.2 
+L 559.564229 389.2 
+L 568.22607 389.2 
+L 568.22607 42.726328 
+L 559.564229 42.726328 
+L 550.902387 42.726328 
+L 550.902387 389.2 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p80254c822f">
+   <rect x="61.882578" y="42.726328" width="477.51346" height="346.473672"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/public/images/posts/benchmark-embeddings/quantization.svg
+++ b/public/images/posts/benchmark-embeddings/quantization.svg
@@ -1,0 +1,2274 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="432pt" viewBox="0 0 648 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-30T15:37:11.480435</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432 
+L 648 432 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 85.975 389.2 
+L 637.2 389.2 
+L 637.2 43.446328 
+L 85.975 43.446328 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 125.348214 389.2 
+L 125.348214 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mc9fba8ee2b" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="125.348214" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −5 -->
+      <g transform="translate(117.977121 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-c9c" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(83.796875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 204.094643 389.2 
+L 204.094643 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="204.094643" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −4 -->
+      <g transform="translate(196.723549 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(83.796875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 282.841071 389.2 
+L 282.841071 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="282.841071" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- −3 -->
+      <g transform="translate(275.469978 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(83.796875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 361.5875 389.2 
+L 361.5875 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="361.5875" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- −2 -->
+      <g transform="translate(354.216406 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(83.796875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 440.333929 389.2 
+L 440.333929 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="440.333929" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- −1 -->
+      <g transform="translate(432.962835 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(83.796875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 519.080357 389.2 
+L 519.080357 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="519.080357" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0 -->
+      <g transform="translate(515.899107 403.797656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 597.826786 389.2 
+L 597.826786 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mc9fba8ee2b" x="597.826786" y="389.2" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1 -->
+      <g transform="translate(594.645536 403.797656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- Δ MRR vs full fp32 (puntos ×100) -->
+     <g transform="translate(269.675625 418.558281) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-329" d="M 2188 4044 
+L 906 525 
+L 3472 525 
+L 2188 4044 
+z
+M 50 0 
+L 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 50 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-99" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-329"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(68.40625 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(100.1875 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(186.46875 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(255.953125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.4375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(357.21875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(416.40625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(468.5 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(500.28125 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(535.484375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(598.859375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(626.640625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(654.421875 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(686.203125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(721.40625 0)"/>
+      <use xlink:href="#DejaVuSans-16" transform="translate(784.890625 0)"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(848.515625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(912.140625 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(943.921875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(982.9375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(1046.421875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1109.796875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1173.171875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1212.375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1273.5625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1325.65625 0)"/>
+      <use xlink:href="#DejaVuSans-99" transform="translate(1357.4375 0)"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(1441.234375 0)"/>
+      <use xlink:href="#DejaVuSans-13" transform="translate(1504.859375 0)"/>
+      <use xlink:href="#DejaVuSans-13" transform="translate(1568.484375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1632.109375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_15">
+      <defs>
+       <path id="mb95aee2be2" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="71.251693" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- F2LLM-1.7B -->
+      <g transform="translate(20.717188 75.050521) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-25" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-29"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(57.515625 0)"/>
+       <use xlink:href="#DejaVuSans-2f" transform="translate(121.140625 0)"/>
+       <use xlink:href="#DejaVuSans-2f" transform="translate(176.859375 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(232.578125 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(318.859375 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(354.9375 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(418.5625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(450.34375 0)"/>
+       <use xlink:href="#DejaVuSans-25" transform="translate(513.96875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="103.489798" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- pplx-v1 -->
+      <g transform="translate(41.960938 107.289017) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-5b" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+       <use xlink:href="#DejaVuSans-5b" transform="translate(154.75 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(213.9375 0)"/>
+       <use xlink:href="#DejaVuSans-59" transform="translate(247.328125 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(306.515625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="135.727903" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- pplx-context -->
+      <g transform="translate(16.28125 139.527121) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+       <use xlink:href="#DejaVuSans-5b" transform="translate(154.75 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(213.9375 0)"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(250.015625 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(305 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(366.1875 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(429.5625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(468.765625 0)"/>
+       <use xlink:href="#DejaVuSans-5b" transform="translate(528.546875 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(587.734375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="167.966007" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- F2LLM-0.6B -->
+      <g transform="translate(20.717188 171.764835) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-29"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(57.515625 0)"/>
+       <use xlink:href="#DejaVuSans-2f" transform="translate(121.140625 0)"/>
+       <use xlink:href="#DejaVuSans-2f" transform="translate(176.859375 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(232.578125 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(318.859375 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(354.9375 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(418.5625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(450.34375 0)"/>
+       <use xlink:href="#DejaVuSans-25" transform="translate(513.96875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="200.204112" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- jina-small -->
+      <g transform="translate(30.710938 204.003331) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(27.78125 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(55.5625 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(118.9375 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(180.21875 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(216.296875 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(268.390625 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(365.796875 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(427.078125 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(454.859375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="232.442216" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- harrier -->
+      <g transform="translate(45.420313 236.241435) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4b"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(63.375 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(124.65625 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(164.015625 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(205.125 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(232.90625 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(294.4375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="264.680321" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- Octen-0.6B -->
+      <g transform="translate(22.821875 268.479149) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(78.71875 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(133.703125 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(172.90625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(234.4375 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(297.8125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(333.890625 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(397.515625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(429.296875 0)"/>
+       <use xlink:href="#DejaVuSans-25" transform="translate(492.921875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="296.918426" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- Qwen3-0.6B -->
+      <g transform="translate(17.7 300.717254) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-5a" transform="translate(78.71875 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(160.5 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(222.03125 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(285.40625 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(349.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(385.109375 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(448.734375 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(480.515625 0)"/>
+       <use xlink:href="#DejaVuSans-25" transform="translate(544.140625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="329.15653" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- jina-nano -->
+      <g transform="translate(32.423438 332.955749) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(27.78125 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(55.5625 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(118.9375 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(180.21875 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(216.296875 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(279.671875 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(340.953125 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(404.328125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mb95aee2be2" x="85.975" y="361.394635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- Nemotron-1B -->
+      <g transform="translate(12.382812 365.193463) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(74.8125 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(136.34375 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(233.75 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(294.9375 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(334.140625 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(373.046875 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(434.234375 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(497.609375 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(533.6875 0)"/>
+       <use xlink:href="#DejaVuSans-25" transform="translate(597.3125 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_25">
+    <path d="M 519.080357 389.2 
+L 519.080357 43.446328 
+" clip-path="url(#p4b524df456)" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 85.975 389.2 
+L 85.975 43.446328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 637.2 389.2 
+L 637.2 43.446328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 85.975 389.2 
+L 637.2 389.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 85.975 43.446328 
+L 637.2 43.446328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 519.080357 59.162404 
+L 519.080357 59.162404 
+L 519.080357 67.22193 
+L 519.080357 67.22193 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 519.080357 91.400509 
+L 519.080357 91.400509 
+L 519.080357 99.460035 
+L 519.080357 99.460035 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 519.080357 123.638613 
+L 519.080357 123.638613 
+L 519.080357 131.698139 
+L 519.080357 131.698139 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 519.080357 155.876718 
+L 526.955 155.876718 
+L 526.955 163.936244 
+L 519.080357 163.936244 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 519.080357 188.114823 
+L 519.080357 188.114823 
+L 519.080357 196.174349 
+L 519.080357 196.174349 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 519.080357 220.352927 
+L 519.080357 220.352927 
+L 519.080357 228.412453 
+L 519.080357 228.412453 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 519.080357 252.591032 
+L 519.080357 252.591032 
+L 519.080357 260.650558 
+L 519.080357 260.650558 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 519.080357 284.829136 
+L 519.080357 284.829136 
+L 519.080357 292.888662 
+L 519.080357 292.888662 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 519.080357 317.067241 
+L 519.080357 317.067241 
+L 519.080357 325.126767 
+L 519.080357 325.126767 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 519.080357 349.305346 
+L 542.704286 349.305346 
+L 542.704286 357.364872 
+L 519.080357 357.364872 
+z
+" clip-path="url(#p4b524df456)" style="fill: #2ca02c; opacity: 0.85"/>
+   </g>
+   <g id="text_19">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 65.270292) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-e" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 97.508397) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 129.746501) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- +0.1 -->
+    <g style="fill: #444444" transform="translate(533.254714 161.984606) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 194.222711) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 226.460815) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 258.69892) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 290.937024) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +0.0 -->
+    <g style="fill: #444444" transform="translate(525.380071 323.175129) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- +0.3 -->
+    <g style="fill: #444444" transform="translate(549.004 355.413234) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="patch_17">
+    <path d="M 519.080357 67.22193 
+L 337.963571 67.22193 
+L 337.963571 75.281456 
+L 519.080357 75.281456 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 519.080357 99.460035 
+L 306.465 99.460035 
+L 306.465 107.519561 
+L 519.080357 107.519561 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 519.080357 131.698139 
+L 298.590357 131.698139 
+L 298.590357 139.757666 
+L 519.080357 139.757666 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 519.080357 163.936244 
+L 188.345357 163.936244 
+L 188.345357 171.99577 
+L 519.080357 171.99577 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 519.080357 196.174349 
+L 558.453571 196.174349 
+L 558.453571 204.233875 
+L 519.080357 204.233875 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 519.080357 228.412453 
+L 424.584643 228.412453 
+L 424.584643 236.471979 
+L 519.080357 236.471979 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 519.080357 260.650558 
+L 377.336786 260.650558 
+L 377.336786 268.710084 
+L 519.080357 268.710084 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 519.080357 292.888662 
+L 290.715714 292.888662 
+L 290.715714 300.948189 
+L 519.080357 300.948189 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 519.080357 325.126767 
+L 322.214286 325.126767 
+L 322.214286 333.186293 
+L 519.080357 333.186293 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 519.080357 357.364872 
+L 361.5875 357.364872 
+L 361.5875 365.424398 
+L 519.080357 365.424398 
+z
+" clip-path="url(#p4b524df456)" style="fill: #d62728; opacity: 0.85"/>
+   </g>
+   <g id="text_29">
+    <!-- -2.3 -->
+    <g style="fill: #444444" transform="translate(316.055107 73.329818) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -2.7 -->
+    <g style="fill: #444444" transform="translate(284.556536 105.567923) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -2.8 -->
+    <g style="fill: #444444" transform="translate(276.681893 137.806028) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -4.2 -->
+    <g style="fill: #444444" transform="translate(166.436893 170.044132) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +0.5 -->
+    <g style="fill: #444444" transform="translate(564.753286 202.282237) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -1.2 -->
+    <g style="fill: #444444" transform="translate(402.676179 234.520341) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -1.8 -->
+    <g style="fill: #444444" transform="translate(355.428321 266.758446) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -2.9 -->
+    <g style="fill: #444444" transform="translate(268.80725 298.996551) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- -2.5 -->
+    <g style="fill: #444444" transform="translate(300.305821 331.234655) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- -2.0 -->
+    <g style="fill: #444444" transform="translate(339.679036 363.47276) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="patch_27">
+    <path d="M 519.080357 75.281456 
+L 479.707143 75.281456 
+L 479.707143 83.340983 
+L 519.080357 83.340983 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 519.080357 107.519561 
+L 282.841071 107.519561 
+L 282.841071 115.579087 
+L 519.080357 115.579087 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 519.080357 139.757666 
+L 542.704286 139.757666 
+L 542.704286 147.817192 
+L 519.080357 147.817192 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 519.080357 171.99577 
+L 534.829643 171.99577 
+L 534.829643 180.055296 
+L 519.080357 180.055296 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 519.080357 204.233875 
+L 432.459286 204.233875 
+L 432.459286 212.293401 
+L 519.080357 212.293401 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 519.080357 236.471979 
+L 345.838214 236.471979 
+L 345.838214 244.531506 
+L 519.080357 244.531506 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.080357 268.710084 
+L 345.838214 268.710084 
+L 345.838214 276.76961 
+L 519.080357 276.76961 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 519.080357 300.948189 
+L 448.208571 300.948189 
+L 448.208571 309.007715 
+L 519.080357 309.007715 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 519.080357 333.186293 
+L 519.080357 333.186293 
+L 519.080357 341.245819 
+L 519.080357 341.245819 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 519.080357 365.424398 
+L 456.083214 365.424398 
+L 456.083214 373.483924 
+L 519.080357 373.483924 
+z
+" clip-path="url(#p4b524df456)" style="fill: #1f77b4; opacity: 0.85"/>
+   </g>
+   <g id="text_39">
+    <!-- -0.5 -->
+    <g style="fill: #444444" transform="translate(457.798679 81.389344) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- -3.0 -->
+    <g style="fill: #444444" transform="translate(260.932607 113.627449) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- +0.3 -->
+    <g style="fill: #444444" transform="translate(549.004 145.865554) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- +0.2 -->
+    <g style="fill: #444444" transform="translate(541.129357 178.103658) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-e"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(179.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- -1.1 -->
+    <g style="fill: #444444" transform="translate(410.550821 210.341763) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- -2.2 -->
+    <g style="fill: #444444" transform="translate(323.92975 242.579868) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- -2.2 -->
+    <g style="fill: #444444" transform="translate(323.92975 274.817972) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- -0.9 -->
+    <g style="fill: #444444" transform="translate(426.300107 307.056077) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- -0.8 -->
+    <g style="fill: #444444" transform="translate(434.17475 371.532286) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-10"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(36.078125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(99.703125 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(131.484375 0)"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- Impacto de cuantización y truncado en calidad de recuperación -->
+    <g transform="translate(170.3 22.563047) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5d" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b5" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+M 2393 5119 
+L 3015 5119 
+L 1997 3944 
+L 1518 3944 
+L 2393 5119 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2c"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(29.5 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(126.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(190.390625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(251.671875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(306.65625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(345.859375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(407.046875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(438.828125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(502.3125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(563.84375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(595.625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(650.609375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(713.984375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(775.265625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(838.640625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(877.84375 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(905.625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(958.109375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1019.390625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1074.375 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(1102.15625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1163.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1226.71875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(1258.5 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1317.6875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1349.46875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1388.671875 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1429.78125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1493.15625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1556.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1611.515625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1672.796875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1736.28125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1797.46875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1829.25 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1890.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1954.15625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1985.9375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2040.921875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2102.203125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2129.984375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2157.765625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2221.25 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2282.53125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2346.015625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2377.796875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2441.28125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2502.8125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2534.59375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2573.5 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2635.03125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2690.015625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(2753.390625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2816.875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2878.40625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2919.515625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(2980.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(3035.78125 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(3063.5625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(3124.75 0)"/>
+    </g>
+    <!-- (int8 = cuantización escalar, binary = 1 bit/dim, mrl_768 = Matryoshka a 768) -->
+    <g transform="translate(125.628125 37.446328) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-b"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(39.015625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(66.796875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(130.171875 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(169.375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(233 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(264.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(348.578125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(380.359375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(435.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(498.71875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(560 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(623.375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(662.578125 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(690.359375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(742.84375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(804.125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(859.109375 0)"/>
+     <use xlink:href="#DejaVuSans-b5" transform="translate(886.890625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(948.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1011.453125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1043.234375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1104.765625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1156.859375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1211.84375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1273.125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1300.90625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1362.1875 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1403.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1435.078125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1466.859375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1530.34375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1558.125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1621.5 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1682.78125 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(1723.890625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1783.078125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1814.859375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1898.65625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1930.4375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1994.0625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2025.84375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2089.328125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2117.109375 0)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(2156.3125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2190 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2253.484375 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(2281.265625 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(2378.671875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2410.453125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(2442.234375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2539.640625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2580.75 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(2608.53125 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(2658.53125 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(2722.15625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(2785.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2849.40625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2881.1875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2964.984375 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2996.765625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3083.046875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3144.328125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3183.53125 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(3224.640625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3283.828125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(3345.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(3397.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4e" transform="translate(3460.484375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3516.640625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3577.921875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3609.703125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3670.984375 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(3702.765625 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(3766.390625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(3830.015625 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(3893.640625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_37">
+     <path d="M 92.275 384.7 
+L 157.720469 384.7 
+Q 159.520469 384.7 159.520469 382.9 
+L 159.520469 343.297891 
+Q 159.520469 341.497891 157.720469 341.497891 
+L 92.275 341.497891 
+Q 90.475 341.497891 90.475 343.297891 
+L 90.475 382.9 
+Q 90.475 384.7 92.275 384.7 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_38">
+     <path d="M 94.075 351.936484 
+L 112.075 351.936484 
+L 112.075 345.636484 
+L 94.075 345.636484 
+z
+" style="fill: #2ca02c; opacity: 0.85"/>
+    </g>
+    <g id="text_49">
+     <!-- int8 -->
+     <g transform="translate(119.275 351.936484) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(27.78125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(91.15625 0)"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(130.359375 0)"/>
+     </g>
+    </g>
+    <g id="patch_39">
+     <path d="M 94.075 365.437187 
+L 112.075 365.437187 
+L 112.075 359.137187 
+L 94.075 359.137187 
+z
+" style="fill: #d62728; opacity: 0.85"/>
+    </g>
+    <g id="text_50">
+     <!-- binary -->
+     <g transform="translate(119.275 365.437187) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-45"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(91.265625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(154.640625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(215.921875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(257.03125 0)"/>
+     </g>
+    </g>
+    <g id="patch_40">
+     <path d="M 94.075 378.937891 
+L 112.075 378.937891 
+L 112.075 372.637891 
+L 94.075 372.637891 
+z
+" style="fill: #1f77b4; opacity: 0.85"/>
+    </g>
+    <g id="text_51">
+     <!-- mrl_768 -->
+     <g transform="translate(119.275 378.937891) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(97.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(138.515625 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(166.296875 0)"/>
+      <use xlink:href="#DejaVuSans-1a" transform="translate(216.296875 0)"/>
+      <use xlink:href="#DejaVuSans-19" transform="translate(279.921875 0)"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(343.546875 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4b524df456">
+   <rect x="85.975" y="43.446328" width="551.225" height="345.753672"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/content/blog/es/benchmark-embeddings-dof.md
+++ b/src/content/blog/es/benchmark-embeddings-dof.md
@@ -18,7 +18,7 @@ La elección importa por tres razones:
 - **Costo**: embedder el corpus completo se hace una vez, pero re-indexar con otro modelo cuesta días de cómputo. Hay que elegir bien a la primera.
 - **Almacenamiento**: 1M chunks × 1,024 dimensiones × 4 bytes = 4 GB de vectores. La cuantización puede bajar eso a 1 GB... si no destruye la calidad (ya habíamos explorado esto en las [proyecciones de almacenamiento](/es/blog/2025/09/Proyecciones-de-Almacenamiento-para-DOF-RAG/)).
 
-Evaluamos 10 modelos en dos ejes —velocidad y calidad de recuperación— más un tercer experimento de cuantización y dimensiones. Este post cuenta los resultados.
+Evaluamos 10 modelos en dos ejes —velocidad y calidad de recuperación— más un tercer experimento de cuantización y dimensiones. Todo el código y los reportes están en el PR [#57](https://github.com/CodeandoGuadalajara/dof-rag/pull/57). Este post cuenta los resultados.
 
 ## El setup
 
@@ -108,6 +108,10 @@ El tercer experimento: sobre los mismos embeddings fp32, aplicamos transformacio
 | Qwen3-0.6B | +0.0 | -2.9 | -0.9 |
 | Nemotron-1B | +0.3 | -2.0 | -0.8 |
 
+![Impacto de cuantización int8, binary y truncado Matryoshka a 768 dimensiones sobre el MRR de cada modelo. int8 no pierde calidad en ninguno; binary solo mejora a jina-v5-text-small](/images/posts/benchmark-embeddings/quantization.svg)
+
+*Las barras verdes (int8) están todas pegadas al cero: la compresión 4x es gratis. La única barra roja positiva es jina-v5-text-small, el único modelo entrenado con binary quantization.*
+
 **int8 no cuesta nada.** Entre +0.0 y +0.3 puntos de MRR en los 10 modelos: la reducción 4x de almacenamiento viene sin pérdida medible de calidad. Esto valida la arquitectura planeada: [sqlite-vec](https://github.com/asg017/sqlite-vec) guardando vectores int8, con distancia L2 equivalente a coseno. No hay razón para guardar fp32 en producción.
 
 **Binary solo funciona donde está entrenado.** [jina-v5-text-small](https://huggingface.co/jinaai/jina-embeddings-v5-text-small) es el único modelo que *mejora* con binarización (+0.5 pts) — Jina entrena sus modelos con soporte de binary quantization, y se nota. 128 bytes por vector: todo el corpus cabría en ~128 MB de vectores (ver [proyecciones de almacenamiento](/es/blog/2025/09/Proyecciones-de-Almacenamiento-para-DOF-RAG/)). [harrier](https://huggingface.co/microsoft/harrier-oss-v1-0.6b) (-1.2) y [Octen](https://huggingface.co/Octen/Octen-Embedding-0.6B) (-1.8) degradan poco; el resto pierde 2-4 puntos. Para los F2LLM, prohibido binarizar (-4.2).
@@ -116,16 +120,9 @@ El tercer experimento: sobre los mismos embeddings fp32, aplicamos transformacio
 
 ## La frontera de Pareto
 
-```
-MRR
-0.55 ┤ F2LLM-1.7B●
-0.50 ┤      pplx-v1● pplx-ctx● F2LLM-0.6B●
-0.45 ┤                  jina-sm harrier Octen Qwen3 jina-nano●
-0.40 ┤
-0.35 ┤                                     Nemotron-1B●
-     └─────────────────────────────────────────────────
-      1.7      3.0       3.7            11.3   chunks/s
-```
+![Frontera de Pareto: velocidad de embedding vs MRR para los 10 modelos. F2LLM-v2-1.7B lidera en calidad, jina-nano en velocidad, pplx-v1 y F2LLM-v2-0.6B en el balance](/images/posts/benchmark-embeddings/pareto.svg)
+
+*Gráfica generada con [`scripts/plot_embedding_benchmark.py`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/scripts/plot_embedding_benchmark.py) a partir de los reportes del benchmark (PR [#57](https://github.com/CodeandoGuadalajara/dof-rag/pull/57)). El tamaño del punto es proporcional a los parámetros; el color indica las dimensiones del vector.*
 
 No hay un solo ganador; hay cuatro, según la prioridad:
 

--- a/src/content/blog/es/benchmark-embeddings-dof.md
+++ b/src/content/blog/es/benchmark-embeddings-dof.md
@@ -1,0 +1,171 @@
+---
+title: "Benchmark de embeddings: 10 modelos compiten por entender el DOF (y gana uno de 0.6B)"
+description: "Comparamos 10 modelos de embedding en velocidad, memoria y calidad de recuperación sobre documentos reales del DOF. Probamos cuantización int8, binaria y truncado Matryoshka. Los leaderboards públicos no predijeron al ganador."
+date: "2026-07-30"
+heroImage: ""
+category: "desarrollo"
+tags: ["dof-rag", "embeddings", "benchmark", "rag", "mteb", "decision"]
+author: "Joaquín Bravo Contreras"
+---
+
+## Después del chunker, el modelo
+
+En los posts anteriores resolvimos cómo dividir los documentos del DOF: construimos un [chunker por patrón](/es/blog/2026/05/chunker-patron-dof/) y lo [validamos contra Chonkie](/es/blog/2026/07/custom-vs-chonkie-decision-chunker/). También hicimos una [primera batalla de embeddings en 2025](/es/blog/2025/08/La-batalla-de-los-embeddings-cuando-tres-modelos-de-IA-compiten-por-entender-el-espaol-gubernamental/) con tres modelos comerciales; ahora repetimos el ejercicio en serio, con 10 modelos open corriendo local. El siguiente problema: **¿con qué modelo convertimos ~1 millón de chunks a vectores?**
+
+La elección importa por tres razones:
+
+- **Calidad**: el embedding determina qué tan bien el sistema encuentra el decreto correcto para una pregunta.
+- **Costo**: embedder el corpus completo se hace una vez, pero re-indexar con otro modelo cuesta días de cómputo. Hay que elegir bien a la primera.
+- **Almacenamiento**: 1M chunks × 1,024 dimensiones × 4 bytes = 4 GB de vectores. La cuantización puede bajar eso a 1 GB... si no destruye la calidad (ya habíamos explorado esto en las [proyecciones de almacenamiento](/es/blog/2025/09/Proyecciones-de-Almacenamiento-para-DOF-RAG/)).
+
+Evaluamos 10 modelos en dos ejes —velocidad y calidad de recuperación— más un tercer experimento de cuantización y dimensiones. Este post cuenta los resultados.
+
+## El setup
+
+**Hardware**: MacBook Pro M3 (36 GB RAM) con MPS (Metal Performance Shaders). El servidor de producción es un Hetzner con CPU Ryzen, pero la Mac embeddea 4-6x más rápido, así que la generación de embeddings se hará ahí.
+
+**Velocidad**: 100 archivos DOF (1,378 chunks), batch 32, vía [`sentence-transformers`](https://www.sbert.net/).
+
+**Calidad**: 50 documentos, 100 queries sintéticas (50 títulos de documento + 50 "primeras 20 palabras", simulando queries de lenguaje natural), métricas estándar: Recall@k, MRR, NDCG con similitud coseno.
+
+**Muestra determinística** (seed 42, archivos ordenados): reproducible en cualquier máquina.
+
+## Los 10 competidores
+
+| Modelo | Params | Dims | Por qué entra |
+|---|---|---|---|
+| [pplx-embed-context-v1-0.6b](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b) | 0.6B | 1,024 | Nuestro candidato original: contextual (late chunking), ONNX local |
+| [pplx-embed-v1-0.6b](https://huggingface.co/perplexity-ai/pplx-embed-v1-0.6b) | 0.6B | 1,024 | Su hermano no-contextual |
+| [F2LLM-v2-1.7B](https://huggingface.co/codefuse-ai/F2LLM-v2-1.7B) | 1.7B | 2,048 | Fuerte en MTEB(Law) |
+| [F2LLM-v2-0.6B](https://huggingface.co/codefuse-ai/F2LLM-v2-0.6B) | 0.6B | 1,024 | El mismo, en tamaño chico |
+| [jina-embeddings-v5-text-small](https://huggingface.co/jinaai/jina-embeddings-v5-text-small) | 0.6B | 1,024 | Soporta binary quantization |
+| [jina-embeddings-v5-text-nano](https://huggingface.co/jinaai/jina-embeddings-v5-text-nano) | 0.2B | 768 | El más chico de todos |
+| [Octen-Embedding-0.6B](https://huggingface.co/Octen/Octen-Embedding-0.6B) | 0.6B | 1,024 | Top-15 mundial en RTEB multilingual |
+| [Nemotron-3-Embed-1B](https://huggingface.co/nvidia/Nemotron-3-Embed-1B-BF16) | 1.1B | 2,048 | NVIDIA, dims altas |
+| [harrier-oss-v1-0.6b](https://huggingface.co/microsoft/harrier-oss-v1-0.6b) | 0.6B | 1,024 | Debut open de Microsoft |
+| [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 0.6B | 1,024 | El más descargado del leaderboard (10.5M) |
+
+## Resultado 1: la tabla maestra
+
+| Modelo | Dims | Chunks/s | Recall@1 | Recall@5 | MRR |
+|---|---|---|---|---|---|
+| **[F2LLM-v2-1.7B](https://huggingface.co/codefuse-ai/F2LLM-v2-1.7B)** | 2,048 | 1.7 | **0.500** | 0.620 | **0.542** |
+| [pplx-embed-v1](https://huggingface.co/perplexity-ai/pplx-embed-v1-0.6b) | 1,024 | 3.3 | 0.450 | 0.610 | 0.512 |
+| [pplx-embed-context-v1](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b) | 1,024 | 3.2 | 0.420 | **0.650** | 0.511 |
+| **[F2LLM-v2-0.6B](https://huggingface.co/codefuse-ai/F2LLM-v2-0.6B)** | 1,024 | **3.7** | 0.440 | 0.590 | 0.500 |
+| [jina-v5-text-small](https://huggingface.co/jinaai/jina-embeddings-v5-text-small) | 1,024 | 2.8 | 0.410 | 0.560 | 0.464 |
+| [harrier-oss-v1-0.6b](https://huggingface.co/microsoft/harrier-oss-v1-0.6b) | 1,024 | 3.6 | 0.360 | 0.590 | 0.464 |
+| [Octen-0.6B](https://huggingface.co/Octen/Octen-Embedding-0.6B) | 1,024 | 3.6 | 0.410 | 0.530 | 0.455 |
+| [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 1,024 | 3.7 | 0.410 | 0.510 | 0.449 |
+| [jina-v5-text-nano](https://huggingface.co/jinaai/jina-embeddings-v5-text-nano) | 768 | **11.3** | 0.380 | 0.530 | 0.443 |
+| [Nemotron-3-Embed-1B](https://huggingface.co/nvidia/Nemotron-3-Embed-1B-BF16) | 2,048 | 2.7 | 0.300 | 0.440 | 0.359 |
+
+Tres historias aquí.
+
+**[F2LLM-v2-1.7B](https://huggingface.co/codefuse-ai/F2LLM-v2-1.7B) es el mejor en calidad absoluta.** Recall@1 de 0.500: la mitad de las veces, el documento correcto aparece en primer lugar. Pero es el más lento (1.7 chunks/s) y pesa el doble por vector (2,048 dims).
+
+**[F2LLM-v2-0.6B](https://huggingface.co/codefuse-ai/F2LLM-v2-0.6B) es la revelación.** MRR 0.500 — solo 4 puntos abajo de su hermano grande — con 3x menos parámetros y 2.2x más velocidad. La mejor calidad-por-tamaño de todo el benchmark. Agregamos este modelo precisamente para tener la comparación a tamaño igual contra el 1.7B, y resultó ser el hallazgo más útil.
+
+**pplx se mantiene fuerte.** [pplx-embed-v1](https://huggingface.co/perplexity-ai/pplx-embed-v1-0.6b) (0.512) y [pplx-embed-context-v1](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b) (0.511) son #2 y #3. Ojo: context-v1 tiene el mejor Recall@5/@10 (0.650/0.700) y todavía no hemos activado su superpoder: el late chunking contextual, donde los chunks del mismo documento se embeddeen viéndose entre sí (algo que ya exploramos con [encabezados estructurados como contexto](/es/blog/2025/05/Dndole-contexto-a-los-embeddings-Los-encabezados-estructurados/)). Aquí se evaluó como embedder estándar chunk-por-chunk, así que su techo real es más alto.
+
+## Resultado 2: los leaderboards públicos no predijeron nada
+
+Antes de correr el benchmark local, analizamos el [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) usando el dataset [`mteb/results`](https://huggingface.co/datasets/mteb/results) (8.5M scores), filtrando por RTEB multilingual y MTEB(Law). El ranking público decía:
+
+- [Octen-0.6B](https://huggingface.co/Octen/Octen-Embedding-0.6B): **top-15 mundial** en RTEB multilingual (74.94)
+- [Qwen3-Embedding](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B): la familia más descargada ([anuncio oficial](https://qwenlm.github.io/blog/qwen3-embedding/)), arriba de Octen y jina en RTEB
+- [Nemotron-3-Embed-1B](https://huggingface.co/nvidia/Nemotron-3-Embed-1B-BF16): 73.66 en RTEB, sólido
+
+En nuestro corpus de español legal mexicano:
+
+- **[Octen-0.6B](https://huggingface.co/Octen/Octen-Embedding-0.6B) quedó media tabla** (0.455, #7 de 10)
+- **[Qwen3-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) quedó debajo de Octen y jina** (0.449), invirtiendo el orden del leaderboard
+- **[Nemotron-1B](https://huggingface.co/nvidia/Nemotron-3-Embed-1B-BF16) fue el peor de todos** (0.359), y encima lento y con el doble de dims
+- Los modelos [pplx](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b) **ni siquiera aparecen en el leaderboard**, y aquí son #2 y #3
+
+La explicación: los tasks de MTEB(Law) son en inglés, alemán y chino (AILA, LegalBench, GerDaLIR, LeCaRD). Un modelo que gana en ley inglesa no necesariamente entiende un decreto fiscal mexicano. **Lección: el leaderboard sirve para shortlistear candidatos, pero la decisión se toma con un eval sobre tu propio dominio.**
+
+## Resultado 3: la cuantización int8 es gratis
+
+El tercer experimento: sobre los mismos embeddings fp32, aplicamos transformaciones post-hoc y re-medimos calidad:
+
+- **int8**: cuantización escalar por vector (4x menos bytes)
+- **binary**: signo, 1 bit por dimensión (32x menos bytes)
+- **mrl_768**: truncado [Matryoshka](https://arxiv.org/abs/2205.13147) a 768 dimensiones
+
+Δ MRR vs full fp32:
+
+| Modelo | int8 | binary | mrl_768 |
+|---|---|---|---|
+| pplx-embed-context-v1 | +0.0 | -2.8 | **+0.3** |
+| pplx-embed-v1 | +0.0 | -2.7 | -3.0 |
+| F2LLM-v2-1.7B | +0.0 | -2.3 | -0.5 |
+| F2LLM-v2-0.6B | +0.1 | -4.2 | +0.2 |
+| jina-v5-text-small | +0.0 | **+0.5** | -1.1 |
+| jina-v5-text-nano | +0.0 | -2.5 | (768 nativo) |
+| harrier-oss | +0.0 | -1.2 | -2.2 |
+| Octen-0.6B | +0.0 | -1.8 | -2.2 |
+| Qwen3-0.6B | +0.0 | -2.9 | -0.9 |
+| Nemotron-1B | +0.3 | -2.0 | -0.8 |
+
+**int8 no cuesta nada.** Entre +0.0 y +0.3 puntos de MRR en los 10 modelos: la reducción 4x de almacenamiento viene sin pérdida medible de calidad. Esto valida la arquitectura planeada: [sqlite-vec](https://github.com/asg017/sqlite-vec) guardando vectores int8, con distancia L2 equivalente a coseno. No hay razón para guardar fp32 en producción.
+
+**Binary solo funciona donde está entrenado.** [jina-v5-text-small](https://huggingface.co/jinaai/jina-embeddings-v5-text-small) es el único modelo que *mejora* con binarización (+0.5 pts) — Jina entrena sus modelos con soporte de binary quantization, y se nota. 128 bytes por vector: todo el corpus cabría en ~128 MB de vectores (ver [proyecciones de almacenamiento](/es/blog/2025/09/Proyecciones-de-Almacenamiento-para-DOF-RAG/)). [harrier](https://huggingface.co/microsoft/harrier-oss-v1-0.6b) (-1.2) y [Octen](https://huggingface.co/Octen/Octen-Embedding-0.6B) (-1.8) degradan poco; el resto pierde 2-4 puntos. Para los F2LLM, prohibido binarizar (-4.2).
+
+**Truncar a 768 no compensa.** Casi todos pierden 0.5-3 puntos al cortar dimensiones. Ni siquiera Qwen3 — que sí está entrenado con Matryoshka — sale ileso (-0.9). Las excepciones curiosas: pplx-context (+0.3) y F2LLM-0.6B (+0.2) no pierden nada, aunque eso es ruido estadístico. La conclusión práctica: **si int8 te da 4x gratis, no tiene sentido pagar calidad por otro 25% de espacio**. Mejor int8 a dimensiones nativas.
+
+## La frontera de Pareto
+
+```
+MRR
+0.55 ┤ F2LLM-1.7B●
+0.50 ┤      pplx-v1● pplx-ctx● F2LLM-0.6B●
+0.45 ┤                  jina-sm harrier Octen Qwen3 jina-nano●
+0.40 ┤
+0.35 ┤                                     Nemotron-1B●
+     └─────────────────────────────────────────────────
+      1.7      3.0       3.7            11.3   chunks/s
+```
+
+No hay un solo ganador; hay cuatro, según la prioridad:
+
+- **Máxima calidad**: [F2LLM-v2-1.7B](https://huggingface.co/codefuse-ai/F2LLM-v2-1.7B) (MRR 0.542) — si aceptamos ~7 días de indexación del corpus completo
+- **Calidad por tamaño**: [F2LLM-v2-0.6B](https://huggingface.co/codefuse-ai/F2LLM-v2-0.6B) (0.500 a 3.7 chunks/s) — 94% de la calidad del grande a mitad de precio de almacenamiento
+- **Balance + late chunking**: [pplx-embed-context-v1](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b) — con la ventaja contextual todavía sin explotar
+- **Escala extrema**: [jina-v5-small](https://huggingface.co/jinaai/jina-embeddings-v5-text-small) binario (128 B/vec) o [jina-v5-nano](https://huggingface.co/jinaai/jina-embeddings-v5-text-nano) (11.3 chunks/s, corpus en ~25 horas)
+
+## Estimados para el corpus completo (~1M chunks, int8)
+
+| Modelo | Tiempo de embedding | Vectores |
+|---|---|---|
+| jina-v5-text-nano | ~25 h | 0.75 GB |
+| harrier / Qwen3 / Octen / F2LLM-0.6B | ~75 h | 1 GB |
+| pplx-v1 / context-v1 | ~85 h | 1 GB |
+| jina-v5-small | ~99 h | 1 GB |
+| F2LLM-v2-1.7B | ~163 h | 2 GB |
+
+## Lecciones
+
+1. **El tamaño no es la calidad.** [F2LLM-0.6B](https://huggingface.co/codefuse-ai/F2LLM-v2-0.6B) casi empata a su hermano 1.7B; [jina-nano](https://huggingface.co/jinaai/jina-embeddings-v5-text-nano) (0.2B) queda a 13% de modelos 3x más grandes. En embeddings, el entrenamiento pesa más que los parámetros.
+
+2. **Los benchmarks públicos son en inglés.** [MTEB(Law)](https://huggingface.co/spaces/mteb/leaderboard) evalúa ley inglesa/alemana/china. Para español jurídico mexicano, el orden se invierte. El eval local no es opcional.
+
+3. **int8 siempre.** Cero pérdida, 4x ahorro. Es la decisión más fácil de todo el proyecto.
+
+4. **La cuantización binaria es una feature del modelo, no del formato.** Solo funciona donde el entrenamiento la contempló (jina). Binarizar embeddings ajenos cuesta 2-4 puntos de MRR.
+
+5. **Medir velocidad en el hardware real.** La Mac M3 embeddea 4-6x más rápido que el servidor Hetzner (CPU). La estrategia: generar embeddings en la Mac, servir búsquedas en Hetzner.
+
+## Código y benchmarks
+
+- Scripts: [`scripts/compare_embeddings.py`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/scripts/compare_embeddings.py) y [`scripts/evaluate_retrieval.py`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/scripts/evaluate_retrieval.py) (PR [#57](https://github.com/CodeandoGuadalajara/dof-rag/pull/57))
+- Reporte unificado: [`reports/embedding_comparison_full.md`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/reports/embedding_comparison_full.md)
+- Análisis del MTEB leaderboard: [`reports/embedding_model_candidates.md`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/reports/embedding_model_candidates.md)
+- Comparación Mac vs Hetzner: [`reports/macos_vs_hetzner.md`](https://github.com/CodeandoGuadalajara/dof-rag/blob/feat/embedding-model-comparison/reports/macos_vs_hetzner.md)
+
+## Siguientes pasos
+
+- **Late chunking real** para [pplx-embed-context-v1](https://huggingface.co/perplexity-ai/pplx-embed-context-v1-0.6b): su ventaja contextual aún no está activada en este eval (ya dimos un primer paso con [encabezados estructurados](/es/blog/2025/05/Dndole-contexto-a-los-embeddings-Los-encabezados-estructurados/))
+- Probar los candidatos Tier 1 del análisis MTEB que faltan: [Qwen3-Embedding-4B](https://huggingface.co/Qwen/Qwen3-Embedding-4B), [Octen-Embedding-4B](https://huggingface.co/Octen/Octen-Embedding-4B) (el mejor ≤4B en RTEB), y [dinghy-law-0.6b](https://huggingface.co/Hanno-Labs/dinghy-law-0.6b-v1) (especializado en ley)
+- Medir latencia de búsqueda [sqlite-vec](https://github.com/asg017/sqlite-vec) con vectores int8
+- Decisión final de producción y generación del corpus completo


### PR DESCRIPTION
Covers the full embedding model comparison: master table (speed + retrieval quality), MTEB leaderboard mismatch with local results, int8/binary/MRL-768 quantization experiment, Pareto frontier, and corpus-scale estimates. Links every model to its Hugging Face page and cross-links related posts (2025 embedding battle, structured headers, storage projections, chunker posts).