### PR TITLE
Blog: hybrid retrieval + throughput de embeddings en M3 (GGUF/Metal)

### DIFF
--- a/src/content/blog/es/benchmark-hibrido-m3-gguf.md
+++ b/src/content/blog/es/benchmark-hibrido-m3-gguf.md
@@ -1,122 +1,118 @@
 ---
-title: "Hybrid retrieval y throughput de embeddings en la Mac M3"
-description: "Tercera entrega del benchmark: medimos si la M3 puede indexar el corpus completo (sweep de batch/dtype en MPS y puerto a GGUF/Metal) y evaluamos la fusión de BM25 con embeddings (RRF y weighted). La fusión weighted con α=0.5 supera a ambos componentes por separado y define la configuración de producción."
+title: "Búsqueda híbrida: cómo juntar BM25 y embeddings (y hacerlos caber en una laptop)"
+description: "Tercera entrega del benchmark: fusionamos los rankings de BM25 y embeddings y el resultado supera a ambos por separado. También medimos cómo indexar el corpus completo desde la Mac M3: qué sirve (GGUF/Metal), qué no (batches grandes, fp16), y por qué la cuantización binaria de jina decide la arquitectura de almacenamiento."
 date: "2026-08-02"
 heroImage: ""
 category: "desarrollo"
-tags: ["dof-rag", "embeddings", "benchmark", "bm25", "hybrid-retrieval", "gguf", "metal", "apple-silicon"]
+tags: ["dof-rag", "embeddings", "benchmark", "bm25", "hybrid-retrieval", "gguf", "apple-silicon"]
 author: "Joaquín Bravo Contreras"
 ---
 
 ## Motivación
 
-El [benchmark anterior](/es/blog/2026/08/benchmark-embeddings-ronda2-bm25/) cerró con dos pendientes claros:
+El [benchmark anterior](/es/blog/2026/08/benchmark-embeddings-ronda2-bm25/) terminó con una conclusión incómoda y una tarea pendiente.
 
-1. **Hybrid retrieval**: BM25 y embeddings resultaron complementarios por tipo de query. Faltaba medir qué pasa al fusionar los dos rankings.
-2. **Throughput de indexación**: al estimado de 20 a 44 días de cómputo para embeddear el corpus completo (~6.5 millones de chunks) en la Mac M3 le faltaba una revisión de optimización antes de comprometer ese tiempo.
+La conclusión incómoda: BM25 (búsqueda por palabras exactas) y los embeddings (búsqueda por significado) ganan en tipos de pregunta distintos. Si alguien pregunta "¿Qué establece el artículo 5 del Decreto 317?", BM25 gana porque esas palabras aparecen literalmente en el documento. Si alguien pregunta "¿Cuánto ganan los altos funcionarios de la CNDH?", los embeddings ganan porque el documento habla de "MANUAL de percepciones de servidores públicos de mando" y BM25 no encuentra esas palabras en la pregunta. Un sistema que solo use uno de los dos va a fallar en la mitad de las preguntas que le haga un ciudadano.
 
-Este post cubre ambos experimentos y cierra con la configuración elegida para la indexación de producción. Código y reportes en el PR [#59](https://github.com/CodeandoGuadalajara/dof-rag/pull/59).
+La tarea pendiente: indexar el corpus completo (~6.5 millones de chunks) tomaría entre 20 y 44 días de cómputo continuo en la Mac M3 con la configuración que usamos en el benchmark. Antes de comprometer semanas de cómputo había que revisar si ese tiempo se podía reducir.
 
-## Parte 1: throughput de embedding en la M3
+Este post cuenta cómo resolvimos ambas cosas. La respuesta corta: fusionar los dos rankings da un sistema mejor que cualquiera de los dos por separado, y un puerto a GGUF/Metal casi duplica la velocidad de embedding en la M3. Código y reportes en el PR [#59](https://github.com/CodeandoGuadalajara/dof-rag/pull/59).
 
-### Sweep de batch size y dtype en PyTorch MPS
+## ¿Qué es fusionar rankings?
 
-Las velocidades de las rondas anteriores (3.7 chunks/s para F2LLM-v2-0.6B, 2.8 para jina-v5-small) salieron del default de sentence-transformers: batch 32, fp32, sin afinar. La primera prueba fue un sweep de batch (32/64/128/256) por dtype (fp32/fp16) sobre 1,378 chunks de 100 documentos, con [`scripts/bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py).
+Los dos sistemas responden una pregunta devolviendo una lista ordenada de resultados: BM25 ordena por coincidencia de palabras, los embeddings por similitud semántica. Fusionar significa tomar las dos listas y producir una sola lista combinada. Hay dos formas estándar de hacerlo:
 
-| Modelo | fp32 bs=32 | fp32 bs=64 | fp32 bs=128 | fp32 bs=256 | fp16 bs=32 | fp16 bs=64 |
-|---|---|---|---|---|---|---|
-| F2LLM-v2-0.6B | **3.74** | 3.65 | 3.50 | 2.85 | 3.72 | 3.64 |
-| jina-v5-small | **2.93** | 2.23 | 1.34 | OOM | 2.85 | 2.39 |
+- **RRF** (Reciprocal Rank Fusion): ignora los puntajes y solo usa las posiciones. Si un chunk aparece en el lugar 2 de BM25 y en el 7 de vectores, suma puntos por ambas posiciones. Es simple y no requiere calibrar nada.
+- **Weighted**: convierte los puntajes de cada sistema a una escala común (0 a 1 por pregunta) y los combina con un peso α: `α × puntaje_BM25 + (1−α) × puntaje_vectores`. Con α=0.5 ambos sistemas pesan igual; con α=0.75 BM25 pesa el triple.
 
-El default ya era óptimo. Batches más grandes degradan el throughput (los chunks del DOF son largos y la presión de memoria domina), y jina ni siquiera sobrevive a batch 256 en fp32 (MPS OOM). fp16 es numéricamente seguro (coseno 0.9996 contra fp32 en F2LLM, 1.0000 en jina) pero no más rápido. PyTorch MPS no tenía nada escondido.
+Evaluamos ambos métodos sobre el mismo query set de la ronda anterior: 499 documentos, 8,065 chunks y 3,023 preguntas de 6 tipos, con ground truth conocido. El script es [`evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py); los embeddings quedan cacheados en disco, así que probar una combinación nueva de fusión toma minutos.
 
-### GGUF con llama.cpp y Metal
+## Resultado: la fusión gana
 
-La segunda vía fue correr los modelos con llama.cpp sobre Metal, usando [`scripts/bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py) (levanta `llama-server` en modo embedding y mide requests por lotes sobre los mismos 1,378 chunks). Los GGUF ya existen: `mradermacher/F2LLM-v2-0.6B-GGUF` para F2LLM y los GGUF oficiales de `jinaai` para jina-v5.
+| Sistema | MRR | Recall@1 | Recall@5 |
+|---|---|---|---|
+| BM25 solo | 0.616 | 0.561 | 0.687 |
+| F2LLM-0.6B int8 solo | 0.561 | 0.496 | 0.646 |
+| jina-v5-small binary solo | 0.538 | 0.470 | 0.631 |
+| RRF(BM25, F2LLM-int8) | 0.633 | 0.572 | 0.712 |
+| **W0.50(BM25, F2LLM-int8)** | **0.661** | **0.596** | **0.749** |
+| W0.50(BM25, jina-binary) | 0.646 | 0.573 | 0.744 |
 
-| Modelo | PyTorch MPS | GGUF f16 | GGUF Q8_0 | Speedup |
-|---|---|---|---|---|
-| F2LLM-v2-0.6B | 3.74 | **5.34** | 5.15 | 1.43× |
-| jina-v5-small | 2.93 | **5.42** | 5.19 | 1.85× |
+Leyendo la tabla en términos prácticos: de cada 100 preguntas, BM25 solo encuentra el documento correcto en primer lugar 56 veces. El mejor embedding solo, 50 veces. La fusión con pesos iguales, **60 veces**, y dentro del top 5 encuentra el documento 75 veces de 100, contra 69 de BM25. Son 4 a 10 puntos porcentuales de mejora dependiendo de la métrica, sin cambiar ni el modelo ni el índice, solo por combinar dos listas que ya teníamos.
 
-Q8_0 no es más rápido que f16: el cuello de botella es cómputo, no ancho de banda de memoria. Batches más grandes tampoco ayudan aquí. La conclusión práctica es que el camino local más rápido es GGUF f16 con batch 32, y con eso la indexación del corpus completo baja de 20 a 27 días a **~14 días continuos por modelo**.
+RRF también mejora sobre ambos padres, pero queda unos 3 puntos debajo de la fusión ponderada. Y la curva de α es plana entre 0.5 y 0.6, así que no hace falta calibrar el peso con mucha precisión.
 
-### El prefijo de jina que casi pasa desapercibido
+### La perilla α depende del tipo de pregunta
 
-Al verificar que los embeddings GGUF fueran equivalentes a los de sentence-transformers, jina daba un coseno de solo 0.958 (mínimo 0.746). La causa: la configuración de sentence-transformers de jina-v5 antepone `Document: ` a los pasajes y `Query: ` a las queries, y llama.cpp no aplica esos prefijos. Agregando `Document: ` explícitamente, el acuerdo sube a 0.9999.
+El desglose por tipo de query (Recall@1) muestra algo más interesante que el promedio:
 
-Esto importa para producción: si indexamos con el servidor GGUF, los chunks deben llevar el prefijo `Document: ` y las queries `Query: `, o la calidad de recuperación se degrada silenciosamente. Las corridas del benchmark (que usaban sentence-transformers) sí incluían los prefijos, así que los números publicados siguen siendo válidos.
-
-## Parte 2: hybrid retrieval
-
-### Setup
-
-La evaluación usa el query set de la ronda 3 (499 documentos, 8,065 chunks, 3,023 queries en 6 tipos) y fusiona los rankings de BM25 (SQLite FTS5) con los de cada modelo de embedding a nivel chunk. Dos métodos de fusión, implementados en [`scripts/evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py):
-
-- **RRF** (Reciprocal Rank Fusion) con k=60: solo usa las posiciones, no los scores.
-- **Weighted**: normaliza los scores de cada sistema a [0,1] por query (min-max) y combina con `α·BM25 + (1−α)·vectores`, con α en {0.25, 0.4, 0.5, 0.6, 0.75}.
-
-Cada sistema aporta sus top 50 chunks a la fusión. Los embeddings quedan cacheados en disco, así que iterar sobre métodos de fusión toma minutos en lugar de horas.
-
-### Resultado general
-
-| Sistema | MRR | Recall@1 | Recall@5 | Recall@10 |
-|---|---|---|---|---|
-| BM25 solo | 0.616 | 0.561 | 0.687 | 0.728 |
-| F2LLM-0.6B int8 solo | 0.561 | 0.496 | 0.646 | 0.707 |
-| jina-v5-small binary solo | 0.538 | 0.470 | 0.631 | 0.686 |
-| RRF(BM25, F2LLM-int8) | 0.633 | 0.572 | 0.712 | 0.773 |
-| **W0.50(BM25, F2LLM-int8)** | **0.661** | **0.596** | **0.749** | **0.789** |
-| W0.50(BM25, jina-binary) | 0.646 | 0.573 | 0.744 | 0.784 |
-
-La fusión weighted con α=0.5 es el mejor sistema: +4.5 puntos de MRR sobre BM25 solo y +10 sobre el mejor embedding solo. RRF también supera a los dos componentes, pero queda unos 3 puntos debajo de weighted. La curva de α es plana entre 0.5 y 0.6, así que no hace falta afinar el peso con precisión de relojero.
-
-La cuantización se comporta como se esperaba dentro de la fusión: int8 es indistinguible de fp32 (cuarta confirmación en este proyecto), y jina-binary pierde solo ~1 punto en fusión contra los 2 puntos que pierde solo. BM25 compensa justo donde binary degrada.
-
-### Por tipo de query
-
-Recall@1 de los sistemas relevantes, desglosado por tipo:
-
-| Tipo | BM25 | F2LLM int8 | W0.50 F2LLM | W0.25 F2LLM | W0.75 F2LLM |
+| Tipo de pregunta | BM25 | F2LLM int8 | W0.25 | W0.50 | W0.75 |
 |---|---|---|---|---|---|
-| first_words (verbatim) | 0.876 | 0.683 | 0.848 | 0.741 | 0.876 |
-| factual | 0.703 | 0.469 | 0.659 | 0.527 | 0.708 |
-| article_specific | 0.482 | 0.282 | 0.409 | 0.309 | 0.464 |
-| paraphrase | 0.565 | 0.773 | 0.783 | **0.813** | 0.645 |
-| thematic | 0.301 | 0.446 | 0.450 | **0.492** | 0.354 |
-| verbatim_title | 0.222 | 0.220 | 0.238 | 0.226 | 0.246 |
+| factual (términos del doc) | 0.703 | 0.469 | 0.527 | 0.659 | 0.708 |
+| paraphrase (reformulada) | 0.565 | 0.773 | **0.813** | 0.783 | 0.645 |
+| thematic (lenguaje ciudadano) | 0.301 | 0.446 | **0.492** | 0.450 | 0.354 |
 
-Tres observaciones:
+Para preguntas que usan las mismas palabras del documento (`factual`), conviene α=0.75: darle más peso a BM25. Para preguntas reformuladas o en lenguaje ciudadano (`paraphrase`, `thematic`), conviene α=0.25: darle más peso a los vectores. Y en `paraphrase` pasa algo notable: la fusión con α=0.25 (0.813) supera a *los dos* sistemas por separado (0.773 y 0.565). No solo reparte lo mejor de cada uno; la combinación encuentra documentos que ninguno de los dos encontraba solo.
 
-1. **El híbrido cumple la promesa de complementariedad**: con α=0.5 queda cerca del mejor componente en cada tipo y lo supera en Recall@5 y Recall@10 en todos.
-2. **Hay sinergia real en paraphrase**: con α=0.25 el híbrido llega a 0.813, mejor que *ambos* padres por separado (F2LLM 0.773, BM25 0.565). La fusión no solo reparte, suma.
-3. **El α óptimo depende del tipo de query**: las consultas lexicas (factual, first_words, article_specific) rinden mejor con α=0.75 (peso a BM25); las semánticas (paraphrase, thematic) con α=0.25 (peso a vectores). Un α fijo deja entre 2 y 4 puntos de MRR sobre la mesa. Eso es lo que un weighting adaptativo por query, o el routing agéntico propuesto en el post anterior, debería recuperar.
+Un α fijo de 0.5 es un buen compromiso, pero deja entre 2 y 4 puntos de MRR sobre la mesa. Recuperarlos requiere decidir el peso por pregunta, lo cual apunta directo al sistema agéntico del post anterior: un LLM que clasifique la pregunta ("¿esto busca un término exacto o un tema?") y ajuste la fusión, o que llame a cada herramienta de búsqueda según corresponda.
 
-### A nivel chunk
+### La cuantización sobrevive a la fusión
 
-Para las 1,618 queries con ground truth a nivel chunk, la fusión con α=0.75 logra el mejor Recall@5-chunk (0.804) y MRR-chunk (0.705), superando a BM25 solo (0.798 y 0.696). El detalle completo está en [`reports/hybrid_retrieval.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/hybrid_retrieval.md).
+Dos datos que ya veníamos confirmando, ahora en el contexto híbrido:
 
-## Configuración de producción
+- **int8 sigue siendo gratis**: los resultados de F2LLM-int8 son idénticos a fp32 en todas las métricas. Cuarta confirmación en este proyecto.
+- **binary pierde menos en fusión que solo**: jina-binary pierde ~2 puntos de MRR cuando se usa solo, pero solo ~1 punto dentro de la fusión (0.650 vs 0.662 de F2LLM-int8). BM25 compensa justo los casos donde la binarización degrada al embedding.
 
-Con estos resultados, la elección para la primera indexación del corpus completo es la opción económica:
+## Indexar 6.5 millones de chunks desde una laptop
 
-**jina-v5-text-small con cuantización binary + BM25, fusión weighted α=0.5.**
+### Lo que no funcionó: afinar PyTorch
 
-- Calidad: MRR 0.646 en el eval híbrido, 1.5 puntos debajo de F2LLM-0.6B-int8 (0.661).
-- Almacenamiento de vectores para ~6.5M chunks: **0.83 GB** contra 6.7 GB de int8. Esto es lo que hace viable servir el índice sin infraestructura extra.
-- Velocidad de indexación local: 5.42 chunks/s vía GGUF/Metal, ~14 días continuos para el corpus completo.
-- Requisito descubierto en la Parte 1: indexar con prefijo `Document: ` y consultar con prefijo `Query: `.
+Las velocidades del benchmark anterior salieron de la configuración default de sentence-transformers (batch 32, fp32). Probamos si había margen con un sweep de batch size (32 a 256) y fp16 en [`scripts/bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py). No había margen: el default ya era óptimo, batches más grandes *empeoran* el throughput (los chunks del DOF son largos y la memoria aprieta), y fp16 es numéricamente idéntico pero igual de lento. PyTorch MPS ya estaba al límite.
 
-F2LLM-0.6B-int8 queda como la opción de calidad si los 1.5 puntos de MRR resultan necesarios en la práctica. La decisión se puede revisar con el mismo harness una vez que exista el índice completo, porque el cuello de botella de re-indexar es cómputo, no diseño.
+### Lo que sí funcionó: GGUF sobre Metal
+
+llama.cpp es un motor de inferencia en C++ con backend nativo para el GPU de Apple (Metal), distinto de PyTorch. Los modelos se convierten a un formato llamado GGUF, que para nuestros dos candidatos ya existe: `mradermacher/F2LLM-v2-0.6B-GGUF` y los GGUF oficiales de jina. Medimos con [`scripts/bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py), que levanta `llama-server` en modo embedding y le manda los mismos 1,378 chunks del sweep anterior:
+
+| Modelo | PyTorch MPS | GGUF/Metal | Ganancia |
+|---|---|---|---|
+| F2LLM-v2-0.6B | 3.74 chunks/s | 5.34 chunks/s | 1.43× |
+| jina-v5-small | 2.93 chunks/s | 5.42 chunks/s | 1.85× |
+
+Cuantizar los pesos del modelo a Q8 no dio más velocidad (el límite es el cómputo, no la memoria), así que usamos f16. Con estos números, la indexación del corpus completo baja de 20–27 días a **~14 días continuos por modelo** en la laptop. Sigue sin ser trivial, pero ya es un trabajo que se puede dejar corriendo; la alternativa de rentar un GPU en la nube queda disponible si queremos el índice en horas.
+
+### El prefijo que casi arruina el índice silenciosamente
+
+Antes de confiar en los embeddings de llama.cpp verificamos que fueran equivalentes a los de sentence-transformers. F2LLM salió perfecto (similitud de coseno 0.9993). Jina salió mal: 0.958 de promedio, con casos en 0.75. Si hubiéramos indexado así, la búsqueda se habría degradado sin que ningún error lo anunciara.
+
+La causa: sentence-transformers, sin avisar mucho, le antepone el texto `Document: ` a cada chunk y `Query: ` a cada pregunta cuando usa jina-v5 (así viene en la configuración del modelo). llama.cpp no sabe nada de eso y embeddea el texto tal cual. Al agregar los prefijos manualmente, el acuerdo subió a 0.9999. La lección quedó documentada en el reporte: al indexar con el servidor GGUF, los chunks deben llevar `Document: ` y las queries `Query: `.
+
+## La decisión: jina binary, y por qué cambia la arquitectura
+
+Con los experimentos anteriores sobre la mesa, la configuración de producción para la primera indexación completa es:
+
+**jina-v5-text-small con vectores binarios + BM25, fusión weighted α=0.5.**
+
+El razonamiento ya no es solo de calidad (0.650 de MRR, 1.5 puntos abajo de F2LLM-int8), sino de espacio en disco. La [arquitectura de almacenamiento del corpus](https://github.com/CodeandoGuadalajara/dof-rag/blob/main/docs/corpus-storage-architecture.md) guarda el texto de los documentos una sola vez, comprimido con zstd, y los chunks como *referencias* (offsets) dentro de esos documentos en lugar de copiar el texto otra vez. Con ese diseño, el desglose para el corpus completo queda:
+
+| Componente | Tamaño estimado |
+|---|---|
+| Corpus comprimido (zstd) | 2–8 GB |
+| Metadata de chunks (offsets, sin texto) | 1–2 GB |
+| Vectores jina binary (6.5M × 128 bytes) | **0.83 GB** |
+| Vectores F2LLM int8 (alternativa) | 6.7 GB |
+
+Los vectores binarios de jina ocupan un octavo de los int8 y, medido en la fusión, cuestan solo 1.5 puntos de MRR. Eso es lo que hace que el índice completo quepa cómodamente en el disco de la laptop (que hoy tiene 19 GB libres) y después en un servidor modesto.
+
+Una última validación: la arquitectura propone hacer BM25 a nivel *documento* (sobre el texto comprimido) en lugar de a nivel chunk como hicimos en el benchmark. Repetimos la evaluación de fusión con esa granularidad ([`evaluate_hybrid_doclevel.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid_doclevel.py)) y el resultado se mantiene: MRR 0.650 con jina-binary, 0.662 con F2LLM-int8. BM25 a nivel documento es más débil por sí solo (0.589), porque los documentos largos diluyen el puntaje de las palabras, pero la fusión compensa la diferencia por completo. El diseño que cabe en el disco no cuesta calidad.
 
 ## Siguientes pasos
 
-1. **Indexación del corpus completo**: script resumible (un trabajo de 14 días en laptop *va* a ser interrumpido), chunker de producción, embeddings vía GGUF/Metal, sqlite-vec con vectores binary y columnas de metadata (fecha, tipo, sección, emisor) extraídas de las rutas de archivo.
-2. **Weighting adaptativo por query**: el α óptimo varía por tipo de query; con los embeddings ya cacheados, medir el techo de un esquema adaptativo cuesta minutos.
-3. **RAG agéntico**: herramientas de búsqueda con filtros de metadata sobre el índice construido, como se describió en el post anterior.
+1. **Proof of concept de almacenamiento**: construir el corpus comprimido con sqlite-zstd sobre 10,000 documentos, siguiendo los criterios de aceptación de la arquitectura (compresión ≥8×, reconstrucción exacta de chunks desde offsets, FTS5 funcionando sobre la vista comprimida, ingesta reanudable). Ahí mediremos también el tamaño real del índice FTS, el único número que falta por estimar.
+2. **Indexación completa**: con el PoC validado, correr el embedder GGUF sobre los 657,867 documentos (~14 días, con checkpoints para reanudar).
+3. **Peso adaptativo y agente**: usar la perilla α por tipo de pregunta y las herramientas de metadata (fecha, tipo, emisor) descritas en el post anterior.
 
 ## Código y datos
 
 - PR: [#59](https://github.com/CodeandoGuadalajara/dof-rag/pull/59)
-- Scripts: [`bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py), [`bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py), [`evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py)
+- Scripts: [`bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py), [`bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py), [`evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py), [`evaluate_hybrid_doclevel.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid_doclevel.py)
 - Reportes: [`reports/bench_throughput.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/bench_throughput.md), [`reports/hybrid_retrieval.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/hybrid_retrieval.md)

--- a/src/content/blog/es/benchmark-hibrido-m3-gguf.md
+++ b/src/content/blog/es/benchmark-hibrido-m3-gguf.md
@@ -1,0 +1,122 @@
+---
+title: "Hybrid retrieval y throughput de embeddings en la Mac M3"
+description: "Tercera entrega del benchmark: medimos si la M3 puede indexar el corpus completo (sweep de batch/dtype en MPS y puerto a GGUF/Metal) y evaluamos la fusión de BM25 con embeddings (RRF y weighted). La fusión weighted con α=0.5 supera a ambos componentes por separado y define la configuración de producción."
+date: "2026-08-02"
+heroImage: ""
+category: "desarrollo"
+tags: ["dof-rag", "embeddings", "benchmark", "bm25", "hybrid-retrieval", "gguf", "metal", "apple-silicon"]
+author: "Joaquín Bravo Contreras"
+---
+
+## Motivación
+
+El [benchmark anterior](/es/blog/2026/08/benchmark-embeddings-ronda2-bm25/) cerró con dos pendientes claros:
+
+1. **Hybrid retrieval**: BM25 y embeddings resultaron complementarios por tipo de query. Faltaba medir qué pasa al fusionar los dos rankings.
+2. **Throughput de indexación**: al estimado de 20 a 44 días de cómputo para embeddear el corpus completo (~6.5 millones de chunks) en la Mac M3 le faltaba una revisión de optimización antes de comprometer ese tiempo.
+
+Este post cubre ambos experimentos y cierra con la configuración elegida para la indexación de producción. Código y reportes en el PR [#59](https://github.com/CodeandoGuadalajara/dof-rag/pull/59).
+
+## Parte 1: throughput de embedding en la M3
+
+### Sweep de batch size y dtype en PyTorch MPS
+
+Las velocidades de las rondas anteriores (3.7 chunks/s para F2LLM-v2-0.6B, 2.8 para jina-v5-small) salieron del default de sentence-transformers: batch 32, fp32, sin afinar. La primera prueba fue un sweep de batch (32/64/128/256) por dtype (fp32/fp16) sobre 1,378 chunks de 100 documentos, con [`scripts/bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py).
+
+| Modelo | fp32 bs=32 | fp32 bs=64 | fp32 bs=128 | fp32 bs=256 | fp16 bs=32 | fp16 bs=64 |
+|---|---|---|---|---|---|---|
+| F2LLM-v2-0.6B | **3.74** | 3.65 | 3.50 | 2.85 | 3.72 | 3.64 |
+| jina-v5-small | **2.93** | 2.23 | 1.34 | OOM | 2.85 | 2.39 |
+
+El default ya era óptimo. Batches más grandes degradan el throughput (los chunks del DOF son largos y la presión de memoria domina), y jina ni siquiera sobrevive a batch 256 en fp32 (MPS OOM). fp16 es numéricamente seguro (coseno 0.9996 contra fp32 en F2LLM, 1.0000 en jina) pero no más rápido. PyTorch MPS no tenía nada escondido.
+
+### GGUF con llama.cpp y Metal
+
+La segunda vía fue correr los modelos con llama.cpp sobre Metal, usando [`scripts/bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py) (levanta `llama-server` en modo embedding y mide requests por lotes sobre los mismos 1,378 chunks). Los GGUF ya existen: `mradermacher/F2LLM-v2-0.6B-GGUF` para F2LLM y los GGUF oficiales de `jinaai` para jina-v5.
+
+| Modelo | PyTorch MPS | GGUF f16 | GGUF Q8_0 | Speedup |
+|---|---|---|---|---|
+| F2LLM-v2-0.6B | 3.74 | **5.34** | 5.15 | 1.43× |
+| jina-v5-small | 2.93 | **5.42** | 5.19 | 1.85× |
+
+Q8_0 no es más rápido que f16: el cuello de botella es cómputo, no ancho de banda de memoria. Batches más grandes tampoco ayudan aquí. La conclusión práctica es que el camino local más rápido es GGUF f16 con batch 32, y con eso la indexación del corpus completo baja de 20 a 27 días a **~14 días continuos por modelo**.
+
+### El prefijo de jina que casi pasa desapercibido
+
+Al verificar que los embeddings GGUF fueran equivalentes a los de sentence-transformers, jina daba un coseno de solo 0.958 (mínimo 0.746). La causa: la configuración de sentence-transformers de jina-v5 antepone `Document: ` a los pasajes y `Query: ` a las queries, y llama.cpp no aplica esos prefijos. Agregando `Document: ` explícitamente, el acuerdo sube a 0.9999.
+
+Esto importa para producción: si indexamos con el servidor GGUF, los chunks deben llevar el prefijo `Document: ` y las queries `Query: `, o la calidad de recuperación se degrada silenciosamente. Las corridas del benchmark (que usaban sentence-transformers) sí incluían los prefijos, así que los números publicados siguen siendo válidos.
+
+## Parte 2: hybrid retrieval
+
+### Setup
+
+La evaluación usa el query set de la ronda 3 (499 documentos, 8,065 chunks, 3,023 queries en 6 tipos) y fusiona los rankings de BM25 (SQLite FTS5) con los de cada modelo de embedding a nivel chunk. Dos métodos de fusión, implementados en [`scripts/evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py):
+
+- **RRF** (Reciprocal Rank Fusion) con k=60: solo usa las posiciones, no los scores.
+- **Weighted**: normaliza los scores de cada sistema a [0,1] por query (min-max) y combina con `α·BM25 + (1−α)·vectores`, con α en {0.25, 0.4, 0.5, 0.6, 0.75}.
+
+Cada sistema aporta sus top 50 chunks a la fusión. Los embeddings quedan cacheados en disco, así que iterar sobre métodos de fusión toma minutos en lugar de horas.
+
+### Resultado general
+
+| Sistema | MRR | Recall@1 | Recall@5 | Recall@10 |
+|---|---|---|---|---|
+| BM25 solo | 0.616 | 0.561 | 0.687 | 0.728 |
+| F2LLM-0.6B int8 solo | 0.561 | 0.496 | 0.646 | 0.707 |
+| jina-v5-small binary solo | 0.538 | 0.470 | 0.631 | 0.686 |
+| RRF(BM25, F2LLM-int8) | 0.633 | 0.572 | 0.712 | 0.773 |
+| **W0.50(BM25, F2LLM-int8)** | **0.661** | **0.596** | **0.749** | **0.789** |
+| W0.50(BM25, jina-binary) | 0.646 | 0.573 | 0.744 | 0.784 |
+
+La fusión weighted con α=0.5 es el mejor sistema: +4.5 puntos de MRR sobre BM25 solo y +10 sobre el mejor embedding solo. RRF también supera a los dos componentes, pero queda unos 3 puntos debajo de weighted. La curva de α es plana entre 0.5 y 0.6, así que no hace falta afinar el peso con precisión de relojero.
+
+La cuantización se comporta como se esperaba dentro de la fusión: int8 es indistinguible de fp32 (cuarta confirmación en este proyecto), y jina-binary pierde solo ~1 punto en fusión contra los 2 puntos que pierde solo. BM25 compensa justo donde binary degrada.
+
+### Por tipo de query
+
+Recall@1 de los sistemas relevantes, desglosado por tipo:
+
+| Tipo | BM25 | F2LLM int8 | W0.50 F2LLM | W0.25 F2LLM | W0.75 F2LLM |
+|---|---|---|---|---|---|
+| first_words (verbatim) | 0.876 | 0.683 | 0.848 | 0.741 | 0.876 |
+| factual | 0.703 | 0.469 | 0.659 | 0.527 | 0.708 |
+| article_specific | 0.482 | 0.282 | 0.409 | 0.309 | 0.464 |
+| paraphrase | 0.565 | 0.773 | 0.783 | **0.813** | 0.645 |
+| thematic | 0.301 | 0.446 | 0.450 | **0.492** | 0.354 |
+| verbatim_title | 0.222 | 0.220 | 0.238 | 0.226 | 0.246 |
+
+Tres observaciones:
+
+1. **El híbrido cumple la promesa de complementariedad**: con α=0.5 queda cerca del mejor componente en cada tipo y lo supera en Recall@5 y Recall@10 en todos.
+2. **Hay sinergia real en paraphrase**: con α=0.25 el híbrido llega a 0.813, mejor que *ambos* padres por separado (F2LLM 0.773, BM25 0.565). La fusión no solo reparte, suma.
+3. **El α óptimo depende del tipo de query**: las consultas lexicas (factual, first_words, article_specific) rinden mejor con α=0.75 (peso a BM25); las semánticas (paraphrase, thematic) con α=0.25 (peso a vectores). Un α fijo deja entre 2 y 4 puntos de MRR sobre la mesa. Eso es lo que un weighting adaptativo por query, o el routing agéntico propuesto en el post anterior, debería recuperar.
+
+### A nivel chunk
+
+Para las 1,618 queries con ground truth a nivel chunk, la fusión con α=0.75 logra el mejor Recall@5-chunk (0.804) y MRR-chunk (0.705), superando a BM25 solo (0.798 y 0.696). El detalle completo está en [`reports/hybrid_retrieval.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/hybrid_retrieval.md).
+
+## Configuración de producción
+
+Con estos resultados, la elección para la primera indexación del corpus completo es la opción económica:
+
+**jina-v5-text-small con cuantización binary + BM25, fusión weighted α=0.5.**
+
+- Calidad: MRR 0.646 en el eval híbrido, 1.5 puntos debajo de F2LLM-0.6B-int8 (0.661).
+- Almacenamiento de vectores para ~6.5M chunks: **0.83 GB** contra 6.7 GB de int8. Esto es lo que hace viable servir el índice sin infraestructura extra.
+- Velocidad de indexación local: 5.42 chunks/s vía GGUF/Metal, ~14 días continuos para el corpus completo.
+- Requisito descubierto en la Parte 1: indexar con prefijo `Document: ` y consultar con prefijo `Query: `.
+
+F2LLM-0.6B-int8 queda como la opción de calidad si los 1.5 puntos de MRR resultan necesarios en la práctica. La decisión se puede revisar con el mismo harness una vez que exista el índice completo, porque el cuello de botella de re-indexar es cómputo, no diseño.
+
+## Siguientes pasos
+
+1. **Indexación del corpus completo**: script resumible (un trabajo de 14 días en laptop *va* a ser interrumpido), chunker de producción, embeddings vía GGUF/Metal, sqlite-vec con vectores binary y columnas de metadata (fecha, tipo, sección, emisor) extraídas de las rutas de archivo.
+2. **Weighting adaptativo por query**: el α óptimo varía por tipo de query; con los embeddings ya cacheados, medir el techo de un esquema adaptativo cuesta minutos.
+3. **RAG agéntico**: herramientas de búsqueda con filtros de metadata sobre el índice construido, como se describió en el post anterior.
+
+## Código y datos
+
+- PR: [#59](https://github.com/CodeandoGuadalajara/dof-rag/pull/59)
+- Scripts: [`bench_throughput.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_throughput.py), [`bench_gguf.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/bench_gguf.py), [`evaluate_hybrid.py`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/scripts/evaluate_hybrid.py)
+- Reportes: [`reports/bench_throughput.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/bench_throughput.md), [`reports/hybrid_retrieval.md`](https://github.com/jackbravo/dof-rag/blob/feat/hybrid-retrieval-m3-gguf/reports/hybrid_retrieval.md)


### PR DESCRIPTION
Post de seguimiento al benchmark ronda 2, cubriendo los dos pendientes que quedaron:

**Parte 1 — Throughput de embedding en la M3**
- Sweep batch × dtype en PyTorch MPS: el default (batch 32, fp32) ya era óptimo; fp16 seguro pero sin ganancia.
- GGUF/llama.cpp con Metal: 5.34 chunks/s F2LLM-0.6B (1.43×) y 5.42 chunks/s jina-v5-small (1.85×). Indexación del corpus completo baja a ~14 días por modelo.
- Hallazgo del prefijo de jina: sentence-transformers antepone `Document: `/`Query: ` y llama.cpp no; sin el prefijo explícito los embeddings GGUF se degradan silenciosamente (coseno 0.958 vs 0.9999).

**Parte 2 — Hybrid retrieval**
- Fusión BM25 + vectores (RRF y weighted min-max) sobre el query set de la ronda 3.
- Weighted α=0.5 es el mejor sistema: MRR 0.661 con F2LLM-int8 (+4.5 sobre BM25 solo, +10 sobre el mejor embedding solo); 0.646 con jina-binary.
- El α óptimo depende del tipo de query (0.75 lexical, 0.25 semántico): motiva weighting adaptativo o routing agéntico.

**Decisión de producción**: jina-v5-small binary + BM25 weighted α=0.5 (0.83 GB de vectores para ~6.5M chunks vs 6.7 GB de int8, a costo de 1.5 pts de MRR).

Acompaña al PR CodeandoGuadalajara/dof-rag#59 (scripts y reportes).

`pnpm run check`: 0 errores. `pnpm run build`: 127 páginas OK.