### PR TITLE
Redesign site with editorial archive identity

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <rect width="64" height="64" rx="6" fill="#f4efe6"/>
-  <path d="M11 5h27l15 15v39H11z" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
-  <path d="M38 5v15h15" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
-  <text x="17" y="44" fill="#173638" font-family="Georgia, 'Times New Roman', serif" font-size="29">D</text>
-  <path d="M35 18v31" stroke="#173638" stroke-width="1.4"/>
-  <circle cx="43" cy="30" r="3.2" fill="#173638"/>
-  <path d="m45 32.5 4.2 7" stroke="#173638" stroke-width="1.5"/>
-  <circle cx="50" cy="42" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="1.5"/>
+  <path d="M11 5h29l13 14v40H11z" fill="none" stroke="#173638" stroke-width="1.2" stroke-linejoin="round"/>
+  <path d="M40 5v14h13" fill="none" stroke="#173638" stroke-width="1.2" stroke-linejoin="round"/>
+  <text x="16" y="44" fill="#173638" font-family="'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif" font-size="20" font-weight="400">D</text>
+  <path d="M33 16v38" stroke="#173638" stroke-width="1.1"/>
+  <circle cx="42" cy="35" r="2.5" fill="#173638"/>
+  <path d="m43.5 37 3 6.5" stroke="#173638" stroke-width="1.2"/>
+  <circle cx="47" cy="45.5" r="1.8" fill="#f4efe6" stroke="#173638" stroke-width="1.2"/>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#f4efe6"/>
-  <path d="M13 7h25l13 13v37H13z" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
-  <path d="M38 7v13h13" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
-  <path d="M33 23v25" stroke="#a64033" stroke-width="2"/>
-  <path d="M20 24v24h5.5c7 0 11-4.4 11-12s-4-12-11-12z" fill="none" stroke="#173638" stroke-width="2.5"/>
-  <circle cx="42" cy="31" r="3.5" fill="#173638"/>
-  <circle cx="47.5" cy="42.5" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="2"/>
-  <path d="m43.5 34 3.2 6" stroke="#173638" stroke-width="2"/>
+  <rect width="64" height="64" rx="6" fill="#f4efe6"/>
+  <path d="M11 5h27l15 15v39H11z" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M38 5v15h15" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
+  <text x="17" y="44" fill="#173638" font-family="Georgia, 'Times New Roman', serif" font-size="29">D</text>
+  <path d="M35 18v31" stroke="#173638" stroke-width="1.4"/>
+  <circle cx="43" cy="30" r="3.2" fill="#173638"/>
+  <path d="m45 32.5 4.2 7" stroke="#173638" stroke-width="1.5"/>
+  <circle cx="50" cy="42" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="1.5"/>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#f4efe6"/>
+  <path d="M13 7h25l13 13v37H13z" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M38 7v13h13" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M33 23v25" stroke="#a64033" stroke-width="2"/>
+  <path d="M20 24v24h5.5c7 0 11-4.4 11-12s-4-12-11-12z" fill="none" stroke="#173638" stroke-width="2.5"/>
+  <circle cx="42" cy="31" r="3.5" fill="#173638"/>
+  <circle cx="47.5" cy="42.5" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="2"/>
+  <path d="m43.5 34 3.2 6" stroke="#173638" stroke-width="2"/>
+</svg>

--- a/public/logo-mark.svg
+++ b/public/logo-mark.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
   <title id="title">DOF-RAG</title>
-  <desc id="desc">Una página con la letra D y un nodo conectado</desc>
-  <rect width="64" height="64" rx="2" fill="#f4efe6"/>
-  <path d="M13 7h25l13 13v37H13z" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
-  <path d="M38 7v13h13" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
-  <path d="M33 23v25" stroke="#a64033" stroke-width="2"/>
-  <path d="M20 24v24h5.5c7 0 11-4.4 11-12s-4-12-11-12z" fill="none" stroke="#173638" stroke-width="2.5"/>
-  <circle cx="42" cy="31" r="3.5" fill="#173638"/>
-  <circle cx="47.5" cy="42.5" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="2"/>
-  <path d="m43.5 34 3.2 6" stroke="#173638" stroke-width="2"/>
+  <desc id="desc">Una página con la letra D y dos nodos conectados</desc>
+  <rect width="64" height="64" fill="#f4efe6"/>
+  <path d="M11 5h27l15 15v39H11z" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M38 5v15h15" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
+  <text x="17" y="44" fill="#173638" font-family="Georgia, 'Times New Roman', serif" font-size="29">D</text>
+  <path d="M35 18v31" stroke="#173638" stroke-width="1.4"/>
+  <circle cx="43" cy="30" r="3.2" fill="#173638"/>
+  <path d="m45 32.5 4.2 7" stroke="#173638" stroke-width="1.5"/>
+  <circle cx="50" cy="42" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="1.5"/>
 </svg>

--- a/public/logo-mark.svg
+++ b/public/logo-mark.svg
@@ -1,12 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
   <title id="title">DOF-RAG</title>
   <desc id="desc">Una página con la letra D y dos nodos conectados</desc>
-  <rect width="64" height="64" fill="#f4efe6"/>
-  <path d="M11 5h27l15 15v39H11z" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
-  <path d="M38 5v15h15" fill="none" stroke="#173638" stroke-width="1.8" stroke-linejoin="round"/>
-  <text x="17" y="44" fill="#173638" font-family="Georgia, 'Times New Roman', serif" font-size="29">D</text>
-  <path d="M35 18v31" stroke="#173638" stroke-width="1.4"/>
-  <circle cx="43" cy="30" r="3.2" fill="#173638"/>
-  <path d="m45 32.5 4.2 7" stroke="#173638" stroke-width="1.5"/>
-  <circle cx="50" cy="42" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="1.5"/>
+  <path d="M11 5h29l13 14v40H11z" fill="none" stroke="#173638" stroke-width="1.2" stroke-linejoin="round"/>
+  <path d="M40 5v14h13" fill="none" stroke="#173638" stroke-width="1.2" stroke-linejoin="round"/>
+  <text x="16" y="44" fill="#173638" font-family="'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif" font-size="20" font-weight="400">D</text>
+  <path d="M33 16v38" stroke="#173638" stroke-width="1.1"/>
+  <circle cx="42" cy="35" r="2.5" fill="#173638"/>
+  <path d="m43.5 37 3 6.5" stroke="#173638" stroke-width="1.2"/>
+  <circle cx="47" cy="45.5" r="1.8" fill="#f4efe6" stroke="#173638" stroke-width="1.2"/>
 </svg>

--- a/public/logo-mark.svg
+++ b/public/logo-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">DOF-RAG</title>
+  <desc id="desc">Una página con la letra D y un nodo conectado</desc>
+  <rect width="64" height="64" rx="2" fill="#f4efe6"/>
+  <path d="M13 7h25l13 13v37H13z" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M38 7v13h13" fill="none" stroke="#173638" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M33 23v25" stroke="#a64033" stroke-width="2"/>
+  <path d="M20 24v24h5.5c7 0 11-4.4 11-12s-4-12-11-12z" fill="none" stroke="#173638" stroke-width="2.5"/>
+  <circle cx="42" cy="31" r="3.5" fill="#173638"/>
+  <circle cx="47.5" cy="42.5" r="2.5" fill="#f4efe6" stroke="#173638" stroke-width="2"/>
+  <path d="m43.5 34 3.2 6" stroke="#173638" stroke-width="2"/>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,28 +1,18 @@
 {
-    "name": "DOF-RAG Blog",
-    "short_name": "DOF-RAG",
-    "description": "Blog sobre Diario Oficial de la Federación con tecnología RAG",
-    "start_url": "./",
-    "display": "standalone",
-    "background_color": "#1a1a1a",
-    "theme_color": "#1a1a1a",
-    "orientation": "portrait-primary",
-    "icons": [
-        {
-            "src": "./favicon.svg",
-            "sizes": "any",
-            "type": "image/svg+xml",
-            "purpose": "any maskable"
-        },
-        {
-            "src": "./android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "./android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ]
+  "name": "DOF-RAG — Archivo computacional abierto",
+  "short_name": "DOF-RAG",
+  "description": "Investigación abierta sobre sistemas de recuperación para el Diario Oficial de la Federación.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#f4efe6",
+  "theme_color": "#173638",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "./favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
 }

--- a/src/components/BlogPostsGrid.astro
+++ b/src/components/BlogPostsGrid.astro
@@ -1,7 +1,5 @@
 ---
-import { Image } from 'astro:assets';
 import { getPostUrlPath } from '../lib/content-utils.ts';
-import { getLangFromUrl } from '../i18n/utils.ts';
 import type { CollectionEntry } from 'astro:content';
 import type { SupportedLanguage } from '../i18n/config.ts';
 
@@ -19,75 +17,199 @@ export interface Props {
 }
 
 const { posts, lang, baseUrl, translations } = Astro.props;
+const sortedPosts = [...posts].sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime()
+);
 
-// Ordenar posts por fecha (más recientes primero)
-const sortedPosts = posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
-
-// Función para formatear la fecha de manera segura
 function formatDate(dateObj: Date): string {
   try {
-    return dateObj.toLocaleDateString(lang === 'es' ? 'es-ES' : 'en-US', {
+    return dateObj.toLocaleDateString(lang === 'es' ? 'es-MX' : 'en-US', {
       year: 'numeric',
-      month: 'long',
-      day: 'numeric'
+      month: 'short',
+      day: 'numeric',
     });
   } catch (error) {
-    console.error(`Error al formatear la fecha:`, error);
+    console.error('Error al formatear la fecha:', error);
     return lang === 'es' ? 'Fecha no disponible' : 'Date not available';
   }
 }
 ---
 
-<div id="posts-container" class="space-y-12">
-  {sortedPosts.map(post => (
-    <article class="blog-card bg-[var(--color-card)] rounded-xl overflow-hidden transition-transform hover:scale-[1.01] hover:shadow-md border border-[var(--color-border)]">
-      <div class="flex flex-col md:flex-row">
-        {post.data.image ? (
-          <div class="md:w-1/3 relative">
-            <a href={`${baseUrl}/${lang}/blog/${getPostUrlPath(post)}`} class="block w-full h-full overflow-hidden">
-              <Image
-                src={`${baseUrl}/${(post.data.image || '').startsWith('/') ? (post.data.image || '').substring(1) : (post.data.image || '')}`}
-                alt={`Imagen para ${post.data.title}`}
-                class="w-full h-48 md:h-full object-cover transition-transform hover:scale-[1.05]"
-                width={800}
-                height={450}
-                loading="lazy"
-                decoding="async"
-              />
-              <div class="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent opacity-0 hover:opacity-100 transition-opacity"></div>
-            </a>
-          </div>
-        ) : null}
-        
-        <div class={`p-6 flex flex-col justify-between ${post.data.image ? 'md:w-2/3' : 'w-full'}`}>
-          <div>
-            <time datetime={typeof post.data.date === 'string' ? post.data.date : post.data.date.toISOString()} class="text-sm text-[var(--color-muted)] block mb-3">
+<div id="posts-container" class="editorial-post-grid">
+  {
+    sortedPosts.map((post, index) => {
+      const postUrl = `${baseUrl}/${lang}/blog/${getPostUrlPath(post)}`;
+      const primaryTag =
+        post.data.tags?.[0] || (lang === 'es' ? 'investigación' : 'research');
+
+      return (
+        <article
+          class:list={['editorial-post-card', { 'is-featured': index === 0 }]}
+        >
+          <div class="post-card-meta">
+            <span>{primaryTag}</span>
+            <time datetime={post.data.date.toISOString()}>
               {formatDate(new Date(post.data.date))}
             </time>
-            <h3 class="text-2xl font-bold mb-3 line-clamp-2">
-              <a href={`${baseUrl}/${lang}/blog/${getPostUrlPath(post)}`} class="hover:text-[var(--color-accent)] transition-colors">
-                {post.data.title}
-              </a>
-            </h3>
-            <p class="text-[var(--color-muted)] mb-4 line-clamp-3">{post.data.description || translations.noDescription}</p>
           </div>
-          
-          <div class="flex justify-between items-center mt-auto">
-            <span class="text-sm text-[var(--color-muted)] flex items-center">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-              </svg>
+
+          <h3>
+            <a href={postUrl}>{post.data.title}</a>
+          </h3>
+          <p class="post-description">
+            {post.data.description || translations.noDescription}
+          </p>
+
+          <footer>
+            <span class="post-author">
               {post.data.author || translations.unknownAuthor}
             </span>
-            <a href={`${baseUrl}/${lang}/blog/${getPostUrlPath(post)}`} class="inline-flex items-center text-[var(--color-accent)] font-medium hover:underline transition-all group">
-              {translations.readMore}
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-1 transform group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
+            <a class="post-read-more" href={postUrl}>
+              {translations.readMore} <span aria-hidden="true">→</span>
             </a>
-          </div>
-        </div>
-      </div>
-    </article>
-  ))}
+          </footer>
+        </article>
+      );
+    })
+  }
 </div>
+
+<style>
+  .editorial-post-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-top: 1px solid var(--color-border);
+    border-left: 1px solid var(--color-border);
+  }
+
+  .editorial-post-card {
+    display: flex;
+    min-height: 20rem;
+    flex-direction: column;
+    border-right: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(var(--color-bg-rgb), 0.64);
+    padding: 1.35rem;
+    transition: background-color 160ms ease;
+  }
+
+  .editorial-post-card:hover {
+    background: var(--color-card);
+  }
+
+  .editorial-post-card.is-featured {
+    grid-column: span 2;
+  }
+
+  .post-card-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
+  }
+
+  .post-card-meta span {
+    color: var(--color-accent);
+    font-weight: 700;
+  }
+
+  .editorial-post-card h3 {
+    margin: 1.1rem 0 0.75rem;
+    font-size: clamp(1.45rem, 2.6vw, 2.05rem);
+    line-height: 1.08;
+  }
+
+  .editorial-post-card.is-featured h3 {
+    max-width: 44rem;
+    font-size: clamp(2rem, 4vw, 3.5rem);
+    letter-spacing: -0.04em;
+  }
+
+  .editorial-post-card h3 a {
+    text-decoration: none;
+  }
+
+  .editorial-post-card h3 a:hover {
+    color: var(--color-accent);
+  }
+
+  .post-description {
+    display: -webkit-box;
+    overflow: hidden;
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.8rem;
+    line-height: 1.55;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+
+  .editorial-post-card.is-featured .post-description {
+    max-width: 44rem;
+    font-size: 0.88rem;
+    -webkit-line-clamp: 3;
+  }
+
+  .editorial-post-card footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: auto;
+    padding-top: 1.5rem;
+  }
+
+  .post-author {
+    color: var(--color-muted);
+    font-size: 0.65rem;
+    line-height: 1.3;
+  }
+
+  .post-read-more {
+    flex: none;
+    border-bottom: 1px solid var(--color-text);
+    padding-bottom: 0.2rem;
+    font-size: 0.68rem;
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  .post-read-more:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  @media (max-width: 920px) {
+    .editorial-post-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 620px) {
+    .editorial-post-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .editorial-post-card,
+    .editorial-post-card.is-featured {
+      grid-column: auto;
+      min-height: 17rem;
+      padding: 1.1rem;
+    }
+
+    .editorial-post-card.is-featured h3 {
+      font-size: 2.15rem;
+    }
+
+    .post-card-meta {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+  }
+</style>

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -2,13 +2,13 @@
   "nav.home": "Home",
   "nav.about": "About",
   "nav.language": "Language",
-  
+
   "footer.title": "DOF-RAG",
   "footer.description": "Research project for processing and analyzing information from the Official Journal of the Federation.",
   "footer.resources": "Resources",
   "footer.contact": "Contact",
   "footer.email": "Email",
-  
+
   "home.title": "DOF-RAG Blog - Home",
   "home.tags": "Tags",
   "home.subscribe": "Subscribe",
@@ -18,16 +18,36 @@
   "home.read_more": "Read more",
   "home.no_more_posts": "No more posts to display",
   "home.subtitle": "Tracking and documenting progress in the development of retrieval and augmented generation systems for the Official Journal of the Federation.",
-  
+  "home.kicker": "Open research on Mexico's Official Journal",
+  "home.hero_lead": "Making Mexico's",
+  "home.hero_emphasis": "regulatory memory",
+  "home.hero_tail": "searchable.",
+  "home.hero_description": "We document how to turn Mexico's Official Journal into a structured, verifiable corpus for artificial-intelligence retrieval systems.",
+  "home.primary_cta": "Read the research",
+  "home.secondary_cta": "About the project",
+  "home.corpus_label": "Canonical corpus",
+  "home.corpus_count": "769,991",
+  "home.corpus_description": "Markdown files processed from official publications.",
+  "home.format_label": "Format",
+  "home.format_value": "Markdown",
+  "home.method_label": "Method",
+  "home.method_value": "Hybrid RAG",
+  "home.access_label": "Access",
+  "home.access_value": "Open",
+  "home.notebook": "Research notebook",
+  "home.notebook_description": "Findings and technical decisions",
+  "home.explore_topics": "Explore by topic",
+  "home.rss_note": "Get new project notes in your preferred feed reader.",
+
   "about.title": "About the project",
   "about.page_title": "About DOF-RAG",
   "about.main_title": "About DOF-RAG",
   "about.subtitle": "Making information from Mexico's Official Journal of the Federation accessible through cutting-edge technologies.",
-  
+
   "about.what_is": "What is DOF-RAG?",
   "about.project_description": "DOF-RAG is a development project that seeks to bring the information from Mexico's Official Journal of the Federation (DOF) closer to the general public. The DOF publishes laws, decrees, and reforms almost daily that impact everyone's lives, but this information is often extensive, technical, and difficult to understand.",
   "about.project_objective": "Our goal is to build a system that allows easily querying and understanding the content of the DOF, using artificial intelligence technologies that explain and summarize the information in a clear and contextualized way.",
-  
+
   "about.how_it_works": "How does the system work?",
   "about.how_it_works_description": "The system we are developing is based on an architecture called RAG (Retrieval-Augmented Generation), which combines intelligent search with advanced language models.",
   "about.how_it_works_additional": "This allows that, when asking a question or searching for a topic, the system locates the relevant information in the DOF documents and generates a clear and understandable response for the user.",
@@ -36,24 +56,27 @@
   "about.process_2": "Semantic indexing, which allows precise searches based on the meaning of the text.",
   "about.process_3": "Generation of answers with language models that explain and contextualize information.",
   "about.process_4": "All this is done with AI tools that work locally, without depending on external services.",
-  
+
   "about.team": "Our team",
   "about.team_description": "We are a group of volunteers with an interest in free access to public information. The team is comprised of:",
   "about.team_member_1": "People with experience in RAG systems and artificial intelligence technologies.",
   "about.team_member_2": "Learners who are learning about natural language processing, creation of question-answering systems, embeddings, and open source language models.",
   "about.team_purpose": "Our work is done collaboratively, with the purpose of contributing to democratic access to legal and regulatory information in Mexico.",
-  
+
   "about.about_blog": "About this blog",
   "about.blog_description": "This blog documents the progress and learnings of the DOF-RAG project. Here we will share news, system improvements, developing ideas, and reflections on how to bring technology closer to people.",
-  
+
   "about.want_to_know_more": "Want to know more?",
   "about.contact_description": "If you have questions, comments, or are interested in collaborating with us, you can write to us at:",
   "about.contact_email": "contacto@dofrag.mx",
-  
+
   "common.unknown_author": "Unknown author",
   "common.date_not_available": "Date not available",
   "common.no_description": "No description available",
-  
+  "common.menu": "Menu",
+  "common.close": "Close",
+  "common.change_theme": "Change theme",
+
   "404.title": "404 - Page Not Found",
   "404.heading": "Page Not Found",
   "404.description": "The page you are looking for doesn't exist or has been moved.",
@@ -67,7 +90,7 @@
   "404.introduction_desc": "General information",
   "404.about": "About",
   "404.about_desc": "Details about the team and methodology",
-  
+
   "tags.title": "Tags | DOF-RAG Blog",
   "tags.heading": "All Tags",
   "tags.description": "Explore our content by topics",
@@ -79,4 +102,4 @@
   "tags.with_tag": "with this tag",
   "tags.read_more": "Read more",
   "tags.no_description": "No description available"
-} 
+}

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -2,13 +2,13 @@
   "nav.home": "Inicio",
   "nav.about": "Acerca de",
   "nav.language": "Idioma",
-  
+
   "footer.title": "DOF-RAG",
   "footer.description": "Proyecto de investigación para el procesamiento y análisis de información del Diario Oficial de la Federación.",
   "footer.resources": "Recursos",
   "footer.contact": "Contacto",
   "footer.email": "Correo",
-  
+
   "home.title": "DOF-RAG Blog - Inicio",
   "home.tags": "Etiquetas",
   "home.subscribe": "Suscríbete",
@@ -18,16 +18,36 @@
   "home.read_more": "Leer más",
   "home.no_more_posts": "No hay más publicaciones para mostrar",
   "home.subtitle": "Seguimiento y documentación de avances en el desarrollo de sistemas de recuperación y generación aumentada para el Diario Oficial de la Federación.",
-  
+  "home.kicker": "Investigación abierta sobre el Diario Oficial",
+  "home.hero_lead": "Hacemos consultable la",
+  "home.hero_emphasis": "memoria normativa",
+  "home.hero_tail": "de México.",
+  "home.hero_description": "Documentamos cómo convertir el Diario Oficial de la Federación en un corpus estructurado, verificable y útil para sistemas de recuperación con inteligencia artificial.",
+  "home.primary_cta": "Leer la investigación",
+  "home.secondary_cta": "Conocer el proyecto",
+  "home.corpus_label": "Corpus canónico",
+  "home.corpus_count": "769,991",
+  "home.corpus_description": "archivos Markdown procesados desde publicaciones oficiales.",
+  "home.format_label": "Formato",
+  "home.format_value": "Markdown",
+  "home.method_label": "Método",
+  "home.method_value": "RAG híbrido",
+  "home.access_label": "Acceso",
+  "home.access_value": "Abierto",
+  "home.notebook": "Cuaderno de investigación",
+  "home.notebook_description": "Hallazgos y decisiones técnicas",
+  "home.explore_topics": "Explorar por tema",
+  "home.rss_note": "Recibe las nuevas notas del proyecto en tu lector preferido.",
+
   "about.title": "Acerca del proyecto",
   "about.page_title": "Acerca de DOF-RAG",
   "about.main_title": "Acerca de DOF-RAG",
   "about.subtitle": "Haciendo accesible la información del Diario Oficial de la Federación mediante tecnologías de vanguardia.",
-  
+
   "about.what_is": "¿Qué es DOF-RAG?",
   "about.project_description": "DOF-RAG es un proyecto en desarrollo que busca acercar la información del Diario Oficial de la Federación (DOF) de México al público general. El DOF publica de forma casi diaria leyes, decretos y reformas que impactan la vida de todas las personas, pero muchas veces esta información es extensa, técnica y difícil de entender.",
   "about.project_objective": "Nuestro objetivo es construir un sistema que permita consultar y comprender fácilmente el contenido del DOF, usando tecnologías de inteligencia artificial que explican y resumen la información de manera clara y contextualizada.",
-  
+
   "about.how_it_works": "¿Cómo funciona el sistema?",
   "about.how_it_works_description": "El sistema que estamos desarrollando se basa en una arquitectura llamada RAG (Retrieval-Augmented Generation), que combina la búsqueda inteligente con modelos de lenguaje avanzados.",
   "about.how_it_works_additional": "Esto permite que, al hacer una pregunta o buscar un tema, el sistema localice la información relevante en los documentos del DOF y genere una respuesta clara y comprensible para el usuario.",
@@ -36,24 +56,27 @@
   "about.process_2": "Indexación semántica, que permite hacer búsquedas precisas basadas en el significado del texto.",
   "about.process_3": "Generación de respuestas con modelos de lenguaje que explican y contextualizan la información.",
   "about.process_4": "Todo esto se realiza con herramientas de IA que funcionan localmente, sin depender de servicios externos.",
-  
+
   "about.team": "Nuestro equipo",
   "about.team_description": "Somos un grupo de personas voluntarias con interés en el acceso libre a la información pública. El equipo está formado por:",
   "about.team_member_1": "Personas con experiencia en sistemas RAG y tecnologías de inteligencia artificial.",
   "about.team_member_2": "Aprendices que están aprendiendo sobre procesamiento de lenguaje natural, creación de sistemas de preguntas y respuestas, embeddings, y modelos de lenguaje de código abierto.",
   "about.team_purpose": "Nuestro trabajo se realiza de forma colaborativa, con el propósito de contribuir al acceso democrático a la información legal y normativa en México.",
-  
+
   "about.about_blog": "Sobre este blog",
   "about.blog_description": "Este blog documenta los avances y aprendizajes del proyecto DOF-RAG. Aquí compartiremos noticias, mejoras del sistema, ideas en desarrollo y reflexiones sobre cómo acercar la tecnología a las personas.",
-  
+
   "about.want_to_know_more": "¿Quieres saber más?",
   "about.contact_description": "Si tienes dudas, comentarios o te interesa colaborar con nosotros, puedes escribirnos a:",
   "about.contact_email": "contacto@dofrag.mx",
-  
+
   "common.unknown_author": "Autor desconocido",
   "common.date_not_available": "Fecha no disponible",
   "common.no_description": "Sin descripción disponible",
-  
+  "common.menu": "Menú",
+  "common.close": "Cerrar",
+  "common.change_theme": "Cambiar tema",
+
   "404.title": "404 - Página no encontrada",
   "404.heading": "Página no encontrada",
   "404.description": "La página que estás buscando no existe o ha sido movida a otra ubicación.",
@@ -67,7 +90,7 @@
   "404.introduction_desc": "Información general",
   "404.about": "Acerca de",
   "404.about_desc": "Detalles sobre el equipo y la metodología",
-  
+
   "tags.title": "Etiquetas | DOF-RAG Blog",
   "tags.heading": "Todas las etiquetas",
   "tags.description": "Explora nuestro contenido por temas",
@@ -79,4 +102,4 @@
   "tags.with_tag": "con esta etiqueta",
   "tags.read_more": "Leer más",
   "tags.no_description": "Sin descripción disponible"
-} 
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,20 +1,27 @@
 ---
 import '../styles/global.css';
-import { getLangFromUrl, getLocalizedPathname, translatePath } from '../i18n/utils.ts';
-import { supportedLanguages, ui, type SupportedLanguage } from '../i18n/config.ts';
+import { getLangFromUrl, getLocalizedPathname } from '../i18n/utils.ts';
+import {
+  supportedLanguages,
+  ui,
+  type SupportedLanguage,
+} from '../i18n/config.ts';
 
 interface Props {
-	title?: string;
+  title?: string;
+  description?: string;
 }
 
-const { title = 'DOF-RAG Blog' } = Astro.props;
+const {
+  title = 'DOF-RAG',
+  description = 'Investigación abierta sobre sistemas de recuperación para el Diario Oficial de la Federación.',
+} = Astro.props;
 const currentPath = Astro.url.pathname;
 const lang = getLangFromUrl(Astro.url) as SupportedLanguage;
-
-// Importar traducciones
-const translations = lang === 'es' 
-  ? await import('../i18n/translations/es.json')
-  : await import('../i18n/translations/en.json');
+const translations =
+  lang === 'es'
+    ? await import('../i18n/translations/es.json')
+    : await import('../i18n/translations/en.json');
 
 function t(key: string): string {
   return (translations.default as Record<string, string>)[key] || key;
@@ -23,210 +30,239 @@ function t(key: string): string {
 
 <!doctype html>
 <html lang={lang}>
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		
-		<!-- Favicons para diferentes navegadores y dispositivos -->
-		<link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
-		<link rel="icon" type="image/x-icon" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
-		<link rel="icon" type="image/png" sizes="16x16" href={`${import.meta.env.BASE_URL}/favicon-16x16.png`} />
-		<link rel="icon" type="image/png" sizes="32x32" href={`${import.meta.env.BASE_URL}/favicon-32x32.png`} />
-		
-		<!-- Apple Touch Icon -->
-		<link rel="apple-touch-icon" sizes="180x180" href={`${import.meta.env.BASE_URL}/apple-touch-icon.png`} />
-		
-		<!-- Android Chrome Icons -->
-		<link rel="icon" type="image/png" sizes="192x192" href={`${import.meta.env.BASE_URL}/android-chrome-192x192.png`} />
-		<link rel="icon" type="image/png" sizes="512x512" href={`${import.meta.env.BASE_URL}/android-chrome-512x512.png`} />
-		
-		<!-- Web App Manifest -->
-		<link rel="manifest" href={`${import.meta.env.BASE_URL}site.webmanifest`} />
-		
-		<!-- Meta tags adicionales para móviles -->
-		<meta name="theme-color" content="#1a1a1a" />
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
-		<meta name="apple-mobile-web-app-title" content="DOF-RAG" />
-		
-		<meta name="generator" content={Astro.generator} />
-		<link rel="alternate" type="application/rss+xml" title="DOF-RAG Blog RSS Feed" href={`${import.meta.env.BASE_URL}rss.xml`} />
-		
-		<!-- SEO para contenido multilingüe -->
-		{supportedLanguages.map(supportedLang => (
-			<link 
-				rel="alternate" 
-				hreflang={supportedLang} 
-				href={getLocalizedPathname(currentPath, supportedLang as SupportedLanguage)} 
-			/>
-		))}
-		
-		<title>{title}</title>
-		<!-- Prevenir el flash de tema incorrecto -->
-		<script is:inline>
-			// Check localStorage first
-			const savedTheme = localStorage.getItem('theme');
-			
-			// If there's a saved preference, apply it; otherwise let the CSS media query handle it
-			if (savedTheme === 'light') {
-				document.documentElement.classList.add('light-theme');
-				document.documentElement.classList.remove('dark-theme');
-			} else if (savedTheme === 'dark') {
-				document.documentElement.classList.add('dark-theme');
-				document.documentElement.classList.remove('light-theme');
-			}
-			// else: no saved preference — CSS @media (prefers-color-scheme: light) handles it
-		</script>
-	</head>
-	<body>
-		<header class="border-b border-[var(--color-border)] py-4 sticky top-0 backdrop-blur-md z-10" style="background-color: rgba(var(--color-bg-rgb), 0.8);">
-			<div class="container flex justify-between items-center">
-				<a href={`${import.meta.env.BASE_URL}/${lang}`} class="text-2xl font-bold flex items-center">
-					<span class="gradient-text">DOF-RAG</span>
-				</a>
-				<nav class="flex items-center gap-6">
-					<a href={`${import.meta.env.BASE_URL}/${lang}`} class="hover:text-[var(--color-accent)]">{t('nav.home')}</a>
-					<a href={`${import.meta.env.BASE_URL}/${lang}/about`} class="hover:text-[var(--color-accent)]">{t('nav.about')}</a>
-          <a href="https://github.com/CodeandoGuadalajara/dof-rag" class="hover:text-[var(--color-accent)]">GitHub</a>
-					
-					<!-- Selector de idioma con clic en lugar de hover -->
-					<div class="relative" id="language-menu">
-						<button id="language-toggle" class="flex items-center hover:text-[var(--color-accent)]">
-							{t('nav.language')}
-							<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-							</svg>
-						</button>
-						<div id="language-dropdown" class="absolute right-0 mt-2 py-2 w-40 bg-[var(--color-card)] rounded-md shadow-xl border border-[var(--color-border)] hidden">
-							{Object.entries(ui).map(([langCode, langName]) => (
-								<a 
-									href={getLocalizedPathname(currentPath, langCode as SupportedLanguage)} 
-									class={`block px-4 py-2 hover:bg-[var(--color-border)] ${lang === langCode ? 'text-[var(--color-accent)]' : ''}`}
-								>
-									{langName}
-								</a>
-							))}
-						</div>
-					</div>
-					
-					<button id="theme-toggle" class="p-2 rounded-full hover:bg-[var(--color-border)] ml-2">
-						<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" id="moon-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-						</svg>
-						<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden" id="sun-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-						</svg>
-					</button>
-				</nav>
-			</div>
-		</header>
-		<main class="container py-12">
-			<slot />
-		</main>
-		<footer class="py-8 border-t border-[var(--color-border)] mt-20">
-			<div class="container">
-				<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-					<div>
-						<h3 class="text-xl font-bold mb-4 gradient-text">{t('footer.title')}</h3>
-						<p class="text-[var(--color-muted)]">
-							{t('footer.description')}
-						</p>
-					</div>
-					<div>
-						<h3 class="text-lg font-bold mb-4">{t('footer.resources')}</h3>
-						<ul class="space-y-2">
-							<li><a href={`${import.meta.env.BASE_URL}/${lang}`} class="text-[var(--color-muted)] hover:text-[var(--color-accent)]">{t('nav.home')}</a></li>
-							<li><a href={`${import.meta.env.BASE_URL}/${lang}/about`} class="text-[var(--color-muted)] hover:text-[var(--color-accent)]">{t('nav.about')}</a></li>
-						</ul>
-					</div>
-					<div>
-						<h3 class="text-lg font-bold mb-4">{t('footer.contact')}</h3>
-						<p class="text-[var(--color-muted)]">
-							{t('footer.email')}: <a href="mailto:contacto@dofrag.mx" class="text-[var(--color-accent)] hover:underline">contacto@dofrag.mx</a>
-						</p>
-					</div>
-				</div>
-			</div>
-		</footer>
-	</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="description" content={description} />
+    <meta name="theme-color" content="#f4efe6" />
+    <meta name="generator" content={Astro.generator} />
+
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href={`${import.meta.env.BASE_URL}/favicon.svg`}
+    />
+    <link
+      rel="manifest"
+      href={`${import.meta.env.BASE_URL}/site.webmanifest`}
+    />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="DOF-RAG RSS"
+      href={`${import.meta.env.BASE_URL}/rss.xml`}
+    />
+
+    {
+      supportedLanguages.map((supportedLang) => (
+        <link
+          rel="alternate"
+          hreflang={supportedLang}
+          href={getLocalizedPathname(
+            currentPath,
+            supportedLang as SupportedLanguage
+          )}
+        />
+      ))
+    }
+
+    <title>{title}</title>
+    <script is:inline>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'light' || savedTheme === 'dark') {
+        document.documentElement.classList.add(`${savedTheme}-theme`);
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header-inner container">
+        <a
+          href={`${import.meta.env.BASE_URL}/${lang}`}
+          class="site-brand"
+          aria-label="DOF-RAG"
+        >
+          <img
+            src={`${import.meta.env.BASE_URL}/logo-mark.svg`}
+            alt=""
+            width="46"
+            height="46"
+          />
+          <span class="site-wordmark">
+            DOF—RAG
+            <small
+              >{
+                lang === 'es'
+                  ? 'Archivo computacional abierto'
+                  : 'Open computational archive'
+              }</small
+            >
+          </span>
+        </a>
+
+        <nav
+          class="desktop-navigation"
+          aria-label={lang === 'es'
+            ? 'Navegación principal'
+            : 'Main navigation'}
+        >
+          <a href={`${import.meta.env.BASE_URL}/${lang}`}>{t('nav.home')}</a>
+          <a href={`${import.meta.env.BASE_URL}/${lang}/about`}
+            >{t('nav.about')}</a
+          >
+
+          <details class="language-menu">
+            <summary>{lang.toUpperCase()}</summary>
+            <div class="language-dropdown">
+              {
+                Object.entries(ui).map(([langCode, langName]) => (
+                  <a
+                    href={getLocalizedPathname(
+                      currentPath,
+                      langCode as SupportedLanguage
+                    )}
+                    aria-current={lang === langCode ? 'page' : undefined}
+                  >
+                    {langName}
+                  </a>
+                ))
+              }
+            </div>
+          </details>
+
+          <button
+            class="theme-toggle"
+            type="button"
+            aria-label={t('common.change_theme')}
+            aria-pressed="false"
+          >
+            <span class="theme-light-icon" aria-hidden="true">☀</span>
+            <span class="theme-dark-icon" aria-hidden="true">◐</span>
+          </button>
+
+          <a
+            class="header-github"
+            href="https://github.com/CodeandoGuadalajara/dof-rag"
+          >
+            GitHub <span aria-hidden="true">↗</span>
+          </a>
+        </nav>
+
+        <details class="mobile-navigation">
+          <summary>{t('common.menu')}</summary>
+          <nav
+            aria-label={lang === 'es'
+              ? 'Navegación móvil'
+              : 'Mobile navigation'}
+          >
+            <a href={`${import.meta.env.BASE_URL}/${lang}`}>{t('nav.home')}</a>
+            <a href={`${import.meta.env.BASE_URL}/${lang}/about`}
+              >{t('nav.about')}</a
+            >
+            <a href="https://github.com/CodeandoGuadalajara/dof-rag">GitHub ↗</a
+            >
+            <div class="mobile-navigation-footer">
+              {
+                Object.entries(ui).map(([langCode, langName]) => (
+                  <a
+                    href={getLocalizedPathname(
+                      currentPath,
+                      langCode as SupportedLanguage
+                    )}
+                    aria-current={lang === langCode ? 'page' : undefined}
+                  >
+                    {langName}
+                  </a>
+                ))
+              }
+              <button
+                class="theme-toggle"
+                type="button"
+                aria-label={t('common.change_theme')}
+                aria-pressed="false"
+              >
+                <span class="theme-light-icon" aria-hidden="true">☀</span>
+                <span class="theme-dark-icon" aria-hidden="true">◐</span>
+              </button>
+            </div>
+          </nav>
+        </details>
+      </div>
+    </header>
+
+    <main class="site-main container">
+      <slot />
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer-inner container">
+        <div class="footer-brand">
+          <img
+            src={`${import.meta.env.BASE_URL}/logo-mark.svg`}
+            alt=""
+            width="38"
+            height="38"
+          />
+          <div>
+            <strong>DOF—RAG</strong>
+            <p>{t('footer.description')}</p>
+          </div>
+        </div>
+        <nav class="footer-navigation" aria-label={t('footer.resources')}>
+          <a href={`${import.meta.env.BASE_URL}/${lang}`}>{t('nav.home')}</a>
+          <a href={`${import.meta.env.BASE_URL}/${lang}/about`}
+            >{t('nav.about')}</a
+          >
+          <a href={`${import.meta.env.BASE_URL}/rss.xml`}>RSS</a>
+          <a href="mailto:contacto@dofrag.mx">contacto@dofrag.mx</a>
+        </nav>
+      </div>
+      <div class="footer-colophon container">
+        <span
+          >{
+            lang === 'es'
+              ? 'Investigación abierta desde México.'
+              : 'Open research from Mexico.'
+          }</span
+        >
+        <span>Codeando Guadalajara</span>
+      </div>
+    </footer>
+  </body>
 </html>
 
 <script>
-	// Tema oscuro/claro
-	const themeToggle = document.getElementById('theme-toggle');
-	const sunIcon = document.getElementById('sun-icon');
-	const moonIcon = document.getElementById('moon-icon');
-	
-	// Set initial state of the toggle based on current theme
-	const isLight = document.documentElement.classList.contains('light-theme') ||
-		(!document.documentElement.classList.contains('dark-theme') &&
-		 window.matchMedia('(prefers-color-scheme: light)').matches);
-	if (isLight) {
-		document.body.classList.add('light-theme');
-		moonIcon?.classList.add('hidden');
-		sunIcon?.classList.remove('hidden');
-	}
-	
-	themeToggle?.addEventListener('click', () => {
-		const goingDark = document.body.classList.contains('light-theme');
-		document.body.classList.toggle('light-theme');
-		document.documentElement.classList.toggle('light-theme');
-		if (goingDark) {
-			document.documentElement.classList.add('dark-theme');
-		} else {
-			document.documentElement.classList.remove('dark-theme');
-		}
-		sunIcon?.classList.toggle('hidden');
-		moonIcon?.classList.toggle('hidden');
-		
-		// Guardar preferencia
-		if (document.body.classList.contains('light-theme')) {
-			localStorage.setItem('theme', 'light');
-		} else {
-			localStorage.setItem('theme', 'dark');
-		}
-	});
-	
-	// Almacenar preferencia de idioma
-	document.addEventListener('DOMContentLoaded', () => {
-		// Obtener idioma actual de la URL
-		const currentPath = window.location.pathname;
-		const segments = currentPath.split('/').filter(Boolean);
-		const currentLang = segments[segments.indexOf('dof-rag-website') + 1] || 'es';
-		
-		if (['es', 'en'].includes(currentLang)) {
-			localStorage.setItem('preferredLanguage', currentLang);
-		}
-		
-		// Menú desplegable de idiomas
-		const languageToggle = document.getElementById('language-toggle');
-		const languageDropdown = document.getElementById('language-dropdown');
-		
-		if (languageToggle && languageDropdown) {
-			// Mostrar/ocultar menú al hacer clic en el botón
-			languageToggle.addEventListener('click', (e) => {
-				e.stopPropagation();
-				languageDropdown.classList.toggle('hidden');
-			});
-			
-			// Cerrar el menú al hacer clic en cualquier lugar fuera de él
-			document.addEventListener('click', (e) => {
-				if (!languageDropdown.contains(e.target as Node) && 
-					!languageToggle.contains(e.target as Node)) {
-					languageDropdown.classList.add('hidden');
-				}
-			});
-			
-			// Evitar que el menú se cierre al hacer clic en él (para poder seleccionar un idioma)
-			languageDropdown.addEventListener('click', (e) => {
-				e.stopPropagation();
-			});
-		}
-	});
-</script>
+  const themeButtons =
+    document.querySelectorAll<HTMLButtonElement>('.theme-toggle');
 
-<style>
-	html {
-		scroll-behavior: smooth;
-	}
-</style>
+  function isLightTheme(): boolean {
+    if (document.documentElement.classList.contains('light-theme')) return true;
+    if (document.documentElement.classList.contains('dark-theme')) return false;
+    return window.matchMedia('(prefers-color-scheme: light)').matches;
+  }
+
+  function syncThemeButtons(): void {
+    const light = isLightTheme();
+    themeButtons.forEach((button) => {
+      button.setAttribute('aria-pressed', String(!light));
+      button
+        .querySelector('.theme-light-icon')
+        ?.classList.toggle('is-hidden', light);
+      button
+        .querySelector('.theme-dark-icon')
+        ?.classList.toggle('is-hidden', !light);
+    });
+  }
+
+  themeButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const nextTheme = isLightTheme() ? 'dark' : 'light';
+      document.documentElement.classList.remove('light-theme', 'dark-theme');
+      document.documentElement.classList.add(`${nextTheme}-theme`);
+      localStorage.setItem('theme', nextTheme);
+      syncThemeButtons();
+    });
+  });
+
+  syncThemeButtons();
+</script>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -134,14 +134,14 @@ export function getStaticPaths() {
 
 <style>
   .editorial-hero {
-    padding: 1.35rem 0 4rem;
+    padding: 0.6rem 0 2.5rem;
   }
 
   .editorial-kicker {
     display: flex;
     align-items: center;
     gap: 0.8rem;
-    margin: 0 0 1.55rem;
+    margin: 0 0 1rem;
     color: var(--color-accent);
     font-family: var(--font-mono);
     font-size: 0.68rem;
@@ -160,16 +160,16 @@ export function getStaticPaths() {
   .editorial-hero-grid {
     display: grid;
     grid-template-columns: minmax(0, 1.55fr) minmax(16rem, 0.55fr);
-    gap: clamp(3rem, 7vw, 6rem);
+    gap: clamp(2.5rem, 5vw, 4.5rem);
   }
 
   .editorial-hero-copy h1 {
     max-width: 54rem;
     margin: 0;
-    font-size: clamp(3.6rem, 7.25vw, 6.85rem);
+    font-size: clamp(3rem, 5vw, 4.9rem);
     font-weight: 650;
-    letter-spacing: -0.062em;
-    line-height: 0.91;
+    letter-spacing: -0.055em;
+    line-height: 0.94;
   }
 
   .editorial-hero-copy h1 em {
@@ -179,11 +179,11 @@ export function getStaticPaths() {
 
   .editorial-intro {
     max-width: 43rem;
-    margin: 2rem 0 1.8rem;
+    margin: 1.35rem 0 1.25rem;
     color: var(--color-muted);
     font-family: var(--font-editorial);
-    font-size: clamp(1.12rem, 1.8vw, 1.42rem);
-    line-height: 1.52;
+    font-size: clamp(1rem, 1.3vw, 1.2rem);
+    line-height: 1.45;
   }
 
   .editorial-actions {
@@ -250,7 +250,7 @@ export function getStaticPaths() {
   }
 
   .ledger-description {
-    margin: 0.5rem 0 1.55rem;
+    margin: 0.5rem 0 1rem;
     color: var(--color-muted);
     font-size: 0.76rem;
     line-height: 1.55;
@@ -265,7 +265,7 @@ export function getStaticPaths() {
     justify-content: space-between;
     gap: 1rem;
     border-top: 1px solid var(--color-border);
-    padding: 0.75rem 0;
+    padding: 0.6rem 0;
     font-family: var(--font-mono);
     font-size: 0.64rem;
   }
@@ -390,32 +390,32 @@ export function getStaticPaths() {
 
   @media (max-width: 760px) {
     .editorial-hero {
-      padding: 0.5rem 0 3rem;
+      padding: 0.25rem 0 2.25rem;
     }
 
     .editorial-hero-grid {
       grid-template-columns: 1fr;
-      gap: 2.35rem;
+      gap: 1.75rem;
     }
 
     .editorial-hero-copy h1 {
-      font-size: clamp(3.1rem, 15vw, 4.65rem);
-      line-height: 0.94;
+      font-size: clamp(2.65rem, 11.5vw, 3.6rem);
+      line-height: 0.96;
     }
 
     .editorial-intro {
-      margin-top: 1.5rem;
-      font-size: 1.08rem;
+      margin-top: 1.15rem;
+      font-size: 1rem;
     }
 
     .corpus-ledger {
       border-top: 1px solid var(--color-border);
       border-left: 0;
-      padding: 1.4rem 0 0;
+      padding: 1rem 0 0;
     }
 
     .ledger-count {
-      font-size: 3.8rem;
+      font-size: 3.15rem;
     }
 
     .research-header {

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -45,8 +45,8 @@ export function getStaticPaths() {
     <div class="editorial-hero-grid">
       <div class="editorial-hero-copy">
         <h1 id="home-title">
-          {t('home.hero_lead')}
-          <em>{t('home.hero_emphasis')}</em>
+          {t('home.hero_lead')}{' '}
+          <em>{t('home.hero_emphasis')}</em>{' '}
           {t('home.hero_tail')}
         </h1>
         <p class="editorial-intro">{t('home.hero_description')}</p>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,126 +6,433 @@ import { getLangFromUrl } from '../../i18n/utils.ts';
 import { supportedLanguages, type SupportedLanguage } from '../../i18n/config';
 import BlogPostsGrid from '../../components/BlogPostsGrid.astro';
 
-// Obtener el idioma actual de la URL
 const lang = getLangFromUrl(Astro.url) as SupportedLanguage;
-
-// Importar traducciones
-const translations = lang === 'es' 
-  ? await import('../../i18n/translations/es.json')
-  : await import('../../i18n/translations/en.json');
+const translations =
+  lang === 'es'
+    ? await import('../../i18n/translations/es.json')
+    : await import('../../i18n/translations/en.json');
 
 function t(key: string): string {
   return (translations.default as Record<string, string>)[key] || key;
 }
 
-// Filtrar posts para el idioma actual
 const allBlogPosts = await getCollection('blog', ({ data, id }) => {
-  // No mostrar borradores
   if (data.draft) return false;
-  
+
   const slug = idToSlug(id);
-  // Si el slug comienza con el idioma actual
   if (slug.startsWith(`${lang}/`)) return true;
-  
-  // Para español (default), incluir posts que no tienen prefijo de idioma
-  if (!slug.startsWith('en/') && !slug.startsWith('es/') && lang === 'es') return true;
-  
+  if (!slug.startsWith('en/') && !slug.startsWith('es/') && lang === 'es')
+    return true;
   return false;
 });
 
-// Extraer tags con conteo de posts
 const tagCounts = new Map<string, number>();
 for (const post of allBlogPosts) {
-  for (const tag of (post.data.tags || [])) {
+  for (const tag of post.data.tags || []) {
     tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
   }
 }
-// Ordenar por frecuencia (más usados primero)
 const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
 
-// Add title letters for blur effect
-const titleText = "DOF-RAG";
-const titleLetters = Array.from(titleText);
-
-// Add subtitle words for blur effect (slightly faster)
-const subtitleText = t('home.subtitle');
-const subtitleWords = subtitleText.split(" ");
-
-// Definir los parámetros estáticos para la generación
 export function getStaticPaths() {
-  return supportedLanguages.map(lang => ({
-    params: { lang }
-  }));
+  return supportedLanguages.map((lang) => ({ params: { lang } }));
 }
 ---
 
-<Layout title={t('home.title')}>
-  <section class="text-center py-16 md:py-24">
-    <h1 class="text-5xl md:text-7xl font-bold mb-6">
-      {titleLetters.map((letter, index) => (
-        <span class="gradient-text title-letter" style={`--delay: ${index * 0.1}s`}>
-          {letter}
-        </span>
-      ))}
-    </h1>
-    <p class="text-xl md:text-2xl max-w-3xl mx-auto text-[var(--color-muted)]">
-      {subtitleWords.map((word, index) => (
-        <span class="subtitle-word" style={`--delay: ${index * 0.05}s`}>
-          {word}
-        </span>
-      ))}
-    </p>
-  </section>
-
-  <div class="grid grid-cols-12 gap-8">
-    <!-- Sidebar con RSS y tags -->
-    <div class="col-span-12 md:col-span-3">
-      <div class="sticky top-24">
-        <div>
-          <h2 class="text-xl font-bold mb-4 pb-2 border-b border-[var(--color-border)]">{t('home.subscribe')}</h2>
-          <p class="text-[var(--color-muted)] text-sm mb-4">{t('home.stay_updated')}</p>
-          <a href={`${import.meta.env.BASE_URL}/rss.xml`} class="inline-block gradient-border px-4 py-2 text-sm font-medium rounded-md hover:opacity-90 flex items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/>
-            </svg>
-            <span class="gradient-text">RSS</span>
+<Layout title={t('home.title')} description={t('home.hero_description')}>
+  <section class="editorial-hero" aria-labelledby="home-title">
+    <p class="editorial-kicker">{t('home.kicker')}</p>
+    <div class="editorial-hero-grid">
+      <div class="editorial-hero-copy">
+        <h1 id="home-title">
+          {t('home.hero_lead')}
+          <em>{t('home.hero_emphasis')}</em>
+          {t('home.hero_tail')}
+        </h1>
+        <p class="editorial-intro">{t('home.hero_description')}</p>
+        <div class="editorial-actions">
+          <a class="primary-action" href="#research">{t('home.primary_cta')}</a>
+          <a
+            class="secondary-action"
+            href={`${import.meta.env.BASE_URL}/${lang}/about`}
+          >
+            {t('home.secondary_cta')}
+            <span aria-hidden="true">→</span>
           </a>
         </div>
+      </div>
 
-        <div class="mt-8">
-          <h2 class="text-xl font-bold mb-4 pb-2 border-b border-[var(--color-border)]">{t('home.tags')}</h2>
-          <div class="flex flex-wrap gap-1.5">
-            {sortedTags.map(([tag, count]) => (
-              <a
-                href={`${import.meta.env.BASE_URL}/${lang}/tags/${tag}`}
-                class="px-2 py-0.5 rounded-full text-xs bg-[var(--color-border)] hover:bg-[var(--color-accent)] hover:text-white transition-colors"
-              >
-                #{tag}
-              </a>
-            ))}
+      <aside class="corpus-ledger" aria-label={t('home.corpus_label')}>
+        <p class="ledger-label">{t('home.corpus_label')}</p>
+        <p class="ledger-count">{t('home.corpus_count')}</p>
+        <p class="ledger-description">{t('home.corpus_description')}</p>
+        <dl>
+          <div>
+            <dt>{t('home.format_label')}</dt><dd>{t('home.format_value')}</dd>
           </div>
-        </div>
+          <div>
+            <dt>{t('home.method_label')}</dt><dd>{t('home.method_value')}</dd>
+          </div>
+          <div>
+            <dt>{t('home.access_label')}</dt><dd>{t('home.access_value')}</dd>
+          </div>
+        </dl>
+      </aside>
+    </div>
+  </section>
+
+  <section
+    id="research"
+    class="research-section"
+    aria-labelledby="research-title"
+  >
+    <header class="research-header">
+      <h2 id="research-title">{t('home.notebook')}</h2>
+      <p>{t('home.notebook_description')}</p>
+    </header>
+
+    <BlogPostsGrid
+      posts={allBlogPosts}
+      lang={lang}
+      baseUrl={import.meta.env.BASE_URL}
+      translations={{
+        readMore: t('home.read_more'),
+        loadMore: t('home.load_more'),
+        noMorePosts: t('home.no_more_posts'),
+        unknownAuthor: t('common.unknown_author'),
+        noDescription: t('common.no_description'),
+      }}
+    />
+  </section>
+
+  <section class="discovery-strip" aria-label={t('home.explore_topics')}>
+    <div class="topics-block">
+      <h2>{t('home.explore_topics')}</h2>
+      <div class="topic-links">
+        {
+          sortedTags.slice(0, 12).map(([tag, count]) => (
+            <a href={`${import.meta.env.BASE_URL}/${lang}/tags/${tag}`}>
+              <>
+                <span>#{tag}</span>
+                <small>{count}</small>
+              </>
+            </a>
+          ))
+        }
       </div>
     </div>
-
-    <!-- Main content -->
-    <div class="col-span-12 md:col-span-9">
-      <h2 class="text-3xl font-bold mb-8">
-        <span class="gradient-text">{t('home.recent_posts')}</span>
-      </h2>
-      
-      <BlogPostsGrid 
-        posts={allBlogPosts} 
-        lang={lang} 
-        baseUrl={import.meta.env.BASE_URL}
-        translations={{
-          readMore: t('home.read_more'),
-          loadMore: t('home.load_more'),
-          noMorePosts: t('home.no_more_posts'),
-          unknownAuthor: t('common.unknown_author'),
-          noDescription: t('common.no_description')
-        }}
-      />
+    <div class="rss-block">
+      <span class="rss-mark" aria-hidden="true">◉</span>
+      <div>
+        <h2>RSS</h2>
+        <p>{t('home.rss_note')}</p>
+      </div>
+      <a href={`${import.meta.env.BASE_URL}/rss.xml`} aria-label="RSS">↗</a>
     </div>
-  </div>
-</Layout> 
+  </section>
+</Layout>
+
+<style>
+  .editorial-hero {
+    padding: 1.35rem 0 4rem;
+  }
+
+  .editorial-kicker {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin: 0 0 1.55rem;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .editorial-kicker::before {
+    width: 2.25rem;
+    height: 1px;
+    background: var(--color-accent);
+    content: '';
+  }
+
+  .editorial-hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(16rem, 0.55fr);
+    gap: clamp(3rem, 7vw, 6rem);
+  }
+
+  .editorial-hero-copy h1 {
+    max-width: 54rem;
+    margin: 0;
+    font-size: clamp(3.6rem, 7.25vw, 6.85rem);
+    font-weight: 650;
+    letter-spacing: -0.062em;
+    line-height: 0.91;
+  }
+
+  .editorial-hero-copy h1 em {
+    color: var(--color-accent);
+    font-style: normal;
+  }
+
+  .editorial-intro {
+    max-width: 43rem;
+    margin: 2rem 0 1.8rem;
+    color: var(--color-muted);
+    font-family: var(--font-editorial);
+    font-size: clamp(1.12rem, 1.8vw, 1.42rem);
+    line-height: 1.52;
+  }
+
+  .editorial-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .primary-action,
+  .secondary-action {
+    font-size: 0.75rem;
+    font-weight: 750;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+  }
+
+  .primary-action {
+    border: 1px solid var(--color-text);
+    background: var(--color-text);
+    color: var(--color-bg);
+    padding: 0.85rem 1.05rem;
+  }
+
+  .primary-action:hover {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+    color: #fffaf1;
+  }
+
+  .secondary-action {
+    border-bottom: 1px solid var(--color-text);
+    padding-block: 0.4rem;
+  }
+
+  .secondary-action:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .corpus-ledger {
+    align-self: stretch;
+    border-left: 1px solid var(--color-border);
+    padding: 0.35rem 0 0 1.75rem;
+  }
+
+  .ledger-label {
+    margin: 0;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    font-weight: 700;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+  }
+
+  .ledger-count {
+    margin: 0.65rem 0 0;
+    font-family: var(--font-editorial);
+    font-size: clamp(2.7rem, 4.2vw, 4.25rem);
+    font-weight: 650;
+    letter-spacing: -0.055em;
+    line-height: 1;
+  }
+
+  .ledger-description {
+    margin: 0.5rem 0 1.55rem;
+    color: var(--color-muted);
+    font-size: 0.76rem;
+    line-height: 1.55;
+  }
+
+  .corpus-ledger dl {
+    margin: 0;
+  }
+
+  .corpus-ledger dl div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    border-top: 1px solid var(--color-border);
+    padding: 0.75rem 0;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+  }
+
+  .corpus-ledger dt {
+    color: var(--color-muted);
+  }
+
+  .corpus-ledger dd {
+    margin: 0;
+    text-align: right;
+  }
+
+  .research-section {
+    scroll-margin-top: 7rem;
+    border-top: 2px solid var(--color-text);
+    padding-top: 1rem;
+  }
+
+  .research-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .research-header h2,
+  .topics-block h2,
+  .rss-block h2 {
+    margin: 0;
+    font-size: clamp(1.65rem, 3vw, 2.35rem);
+  }
+
+  .research-header p {
+    margin: 0;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .discovery-strip {
+    display: grid;
+    grid-template-columns: minmax(0, 1.65fr) minmax(16rem, 0.75fr);
+    gap: 3rem;
+    margin-top: 4rem;
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    padding-block: 1.5rem;
+  }
+
+  .topics-block h2,
+  .rss-block h2 {
+    font-size: 1.35rem;
+  }
+
+  .topic-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.85rem;
+  }
+
+  .topic-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid var(--color-border);
+    padding: 0.4rem 0.55rem;
+    font-size: 0.68rem;
+    text-decoration: none;
+  }
+
+  .topic-links a:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .topic-links small {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+  }
+
+  .rss-block {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.9rem;
+    border-left: 1px solid var(--color-border);
+    padding-left: 1.5rem;
+  }
+
+  .rss-mark {
+    color: var(--color-accent);
+    font-size: 1.2rem;
+  }
+
+  .rss-block p {
+    margin: 0.3rem 0 0;
+    color: var(--color-muted);
+    font-size: 0.7rem;
+    line-height: 1.45;
+  }
+
+  .rss-block > a {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border: 1px solid var(--color-text);
+    text-decoration: none;
+  }
+
+  .rss-block > a:hover {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+    color: #fffaf1;
+  }
+
+  @media (max-width: 760px) {
+    .editorial-hero {
+      padding: 0.5rem 0 3rem;
+    }
+
+    .editorial-hero-grid {
+      grid-template-columns: 1fr;
+      gap: 2.35rem;
+    }
+
+    .editorial-hero-copy h1 {
+      font-size: clamp(3.1rem, 15vw, 4.65rem);
+      line-height: 0.94;
+    }
+
+    .editorial-intro {
+      margin-top: 1.5rem;
+      font-size: 1.08rem;
+    }
+
+    .corpus-ledger {
+      border-top: 1px solid var(--color-border);
+      border-left: 0;
+      padding: 1.4rem 0 0;
+    }
+
+    .ledger-count {
+      font-size: 3.8rem;
+    }
+
+    .research-header {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+
+    .discovery-strip {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .rss-block {
+      border-top: 1px solid var(--color-border);
+      border-left: 0;
+      padding: 1.5rem 0 0;
+    }
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,137 +1,473 @@
-@import "tailwindcss";
-@plugin "@tailwindcss/typography";
+@import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 :root {
-  --color-bg: #13151a;
-  --color-bg-rgb: 19, 21, 26;
-  --color-text: #f3f4f6;
-  --color-accent: #7e22ce;
-  --color-accent-light: #a855f7;
-  --color-muted: #94a3b8;
-  --color-border: #2d303e;
-  --color-card: rgba(26, 28, 35, 0.7);
-  --color-code-text: #c4b5fd;
-  --color-table-head-bg: #2d303e;
-  --color-table-border: #3a3f52;
-  --color-table-row-alt: #1e2029;
-  --color-table-text: #ffffff;
-  --gradient-purple: linear-gradient(135deg, #4c1d95 0%, #8b5cf6 50%, #c026d3 100%);
+  color-scheme: light;
+  --color-bg: #f4efe6;
+  --color-bg-rgb: 244, 239, 230;
+  --color-text: #173638;
+  --color-accent: #a64033;
+  --color-accent-rgb: 166, 64, 51;
+  --color-accent-light: #c36a5d;
+  --color-muted: #5f6e6b;
+  --color-border: #b9b1a2;
+  --color-card: #f8f4ec;
+  --color-paper-deep: #e5ded1;
+  --color-code-text: #8d352c;
+  --color-table-head-bg: #173638;
+  --color-table-border: #b9b1a2;
+  --color-table-row-alt: #ebe4d8;
+  --color-table-text: #fffaf1;
+  --font-editorial:
+    'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia,
+    serif;
+  --font-sans:
+    Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
 }
 
-html.light-theme,
-.light-theme {
-  --color-bg: #ffffff;
-  --color-bg-rgb: 255, 255, 255;
-  --color-text: #1e293b;
-  --color-accent: #7e22ce;
-  --color-accent-light: #a855f7;
-  --color-muted: #64748b;
-  --color-border: #e2e8f0;
-  --color-card: rgba(255, 255, 255, 0.7);
-  --color-code-text: #7e22ce;
-  --color-table-head-bg: #9333ea;
-  --color-table-border: #d8b4fe;
-  --color-table-row-alt: #f5f3ff;
-  --color-table-text: #ffffff;
-  --gradient-purple: linear-gradient(135deg, #c4b5fd 0%, #a855f7 50%, #d946ef 100%);
+html.dark-theme {
+  color-scheme: dark;
+  --color-bg: #101a1b;
+  --color-bg-rgb: 16, 26, 27;
+  --color-text: #f1ecdf;
+  --color-accent: #df7d6d;
+  --color-accent-rgb: 223, 125, 109;
+  --color-accent-light: #efa293;
+  --color-muted: #a9b4af;
+  --color-border: #485553;
+  --color-card: #162324;
+  --color-paper-deep: #213031;
+  --color-code-text: #f2a092;
+  --color-table-head-bg: #243536;
+  --color-table-border: #4c5b59;
+  --color-table-row-alt: #192728;
+  --color-table-text: #f6f0e6;
 }
 
-@media (prefers-color-scheme: light) {
-  :root:not(.dark-theme) {
-    --color-bg: #ffffff;
-    --color-bg-rgb: 255, 255, 255;
-    --color-text: #1e293b;
-    --color-accent: #7e22ce;
-    --color-accent-light: #a855f7;
-    --color-muted: #64748b;
-    --color-border: #e2e8f0;
-    --color-card: rgba(255, 255, 255, 0.7);
-    --color-code-text: #7e22ce;
-    --color-table-head-bg: #9333ea;
-    --color-table-border: #d8b4fe;
-    --color-table-row-alt: #f5f3ff;
-    --color-table-text: #ffffff;
-    --gradient-purple: linear-gradient(135deg, #c4b5fd 0%, #a855f7 50%, #d946ef 100%);
+@media (prefers-color-scheme: dark) {
+  :root:not(.light-theme) {
+    color-scheme: dark;
+    --color-bg: #101a1b;
+    --color-bg-rgb: 16, 26, 27;
+    --color-text: #f1ecdf;
+    --color-accent: #df7d6d;
+    --color-accent-rgb: 223, 125, 109;
+    --color-accent-light: #efa293;
+    --color-muted: #a9b4af;
+    --color-border: #485553;
+    --color-card: #162324;
+    --color-paper-deep: #213031;
+    --color-code-text: #f2a092;
+    --color-table-head-bg: #243536;
+    --color-table-border: #4c5b59;
+    --color-table-row-alt: #192728;
+    --color-table-text: #f6f0e6;
   }
 }
 
 @layer base {
-  html, body {
-    @apply bg-[var(--color-bg)] text-[var(--color-text)] transition-colors duration-200;
-    background-image: 
-      radial-gradient(circle at top right, rgba(124, 58, 237, 0.12), rgba(30, 41, 59, 0) 35%),
-      radial-gradient(circle at bottom left, rgba(139, 92, 246, 0.1), rgba(30, 41, 59, 0) 35%);
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
-    min-height: 100vh;
+  * {
+    box-sizing: border-box;
   }
-  
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-bold;
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    min-height: 100vh;
+    margin: 0;
+    background-color: var(--color-bg);
+    background-image: linear-gradient(
+      90deg,
+      rgba(var(--color-accent-rgb), 0.035) 1px,
+      transparent 1px
+    );
+    background-size: 5rem 100%;
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    text-rendering: optimizeLegibility;
+    transition:
+      background-color 180ms ease,
+      color 180ms ease;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--color-text);
+    font-family: var(--font-editorial);
+    font-weight: 650;
+    letter-spacing: -0.025em;
   }
 
   a {
-    @apply transition-colors duration-200;
+    color: inherit;
+    transition:
+      color 160ms ease,
+      border-color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  button,
+  summary {
+    font: inherit;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 4px;
+  }
+
+  ::selection {
+    background: rgba(var(--color-accent-rgb), 0.2);
   }
 }
 
 @layer components {
   .container {
-    @apply mx-auto px-4 max-w-6xl;
+    width: min(100% - 2rem, 76rem);
+    margin-inline: auto;
   }
-  
-  .blog-card {
-    @apply backdrop-blur-sm transition-all;
+
+  .site-header {
+    position: sticky;
+    z-index: 30;
+    top: 0;
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(var(--color-bg-rgb), 0.94);
+    backdrop-filter: blur(16px);
+  }
+
+  .site-header-inner {
+    position: relative;
+    display: flex;
+    min-height: 5.25rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+  }
+
+  .site-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+  }
+
+  .site-brand img {
+    flex: none;
+    border: 1px solid var(--color-border);
+  }
+
+  .site-wordmark {
+    font-family: var(--font-editorial);
+    font-size: 1.45rem;
+    font-weight: 700;
+    letter-spacing: -0.045em;
+    line-height: 0.95;
+  }
+
+  .site-wordmark small {
+    display: block;
+    margin-top: 0.42rem;
+    font-family: var(--font-sans);
+    font-size: 0.42rem;
+    font-weight: 750;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .desktop-navigation {
+    display: flex;
+    align-items: center;
+    gap: 1.45rem;
+    font-size: 0.78rem;
+    font-weight: 650;
+  }
+
+  .desktop-navigation > a:not(.header-github) {
+    border-bottom: 1px solid transparent;
+    padding-block: 0.4rem;
+    text-decoration: none;
+  }
+
+  .desktop-navigation > a:not(.header-github):hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .header-github {
+    border: 1px solid var(--color-text);
+    padding: 0.65rem 0.85rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .header-github:hover {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+    color: #fffaf1;
+  }
+
+  .language-menu {
+    position: relative;
+  }
+
+  .language-menu summary {
+    cursor: pointer;
+    list-style: none;
+    padding: 0.4rem 0;
+    letter-spacing: 0.08em;
+  }
+
+  .language-menu summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .language-dropdown {
+    position: absolute;
+    top: calc(100% + 0.7rem);
+    right: 0;
+    min-width: 10rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+    box-shadow: 0 1rem 2rem rgba(9, 24, 25, 0.14);
+  }
+
+  .language-dropdown a {
+    display: block;
+    padding: 0.8rem 1rem;
+    text-decoration: none;
+  }
+
+  .language-dropdown a + a {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .language-dropdown a:hover,
+  .language-dropdown a[aria-current='page'] {
+    color: var(--color-accent);
+  }
+
+  .theme-toggle {
+    display: inline-grid;
+    width: 2rem;
+    height: 2rem;
+    cursor: pointer;
+    place-items: center;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-text);
+  }
+
+  .theme-toggle:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .is-hidden {
+    display: none !important;
+  }
+
+  .mobile-navigation {
+    display: none;
+  }
+
+  .site-main {
+    padding-block: 2.75rem 5rem;
+  }
+
+  .site-footer {
+    border-top: 1px solid var(--color-border);
+    background: rgba(var(--color-bg-rgb), 0.84);
+  }
+
+  .site-footer-inner {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 3rem;
+    padding-block: 2.4rem;
+  }
+
+  .footer-brand {
+    display: flex;
+    max-width: 34rem;
+    align-items: flex-start;
+    gap: 0.9rem;
+  }
+
+  .footer-brand img {
+    border: 1px solid var(--color-border);
+  }
+
+  .footer-brand strong {
+    font-family: var(--font-editorial);
+    font-size: 1.1rem;
+  }
+
+  .footer-brand p {
+    margin: 0.35rem 0 0;
+    color: var(--color-muted);
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
+
+  .footer-navigation {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.7rem 1.2rem;
+    font-size: 0.76rem;
+  }
+
+  .footer-navigation a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer-colophon {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--color-border);
+    padding-block: 1rem;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 
   .gradient-text {
-    @apply text-transparent bg-clip-text;
-    background-image: var(--gradient-purple);
+    color: var(--color-accent);
   }
-  
+
   .gradient-border {
-    position: relative;
+    border: 1px solid var(--color-accent);
   }
-  
-  .gradient-border::before {
-    content: "";
+
+  .blog-card {
+    background: var(--color-card);
+  }
+}
+
+@media (max-width: 760px) {
+  .container {
+    width: min(100% - 1.5rem, 76rem);
+  }
+
+  .site-header-inner {
+    min-height: 4.4rem;
+  }
+
+  .site-brand img {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  .site-wordmark {
+    font-size: 1.2rem;
+  }
+
+  .site-wordmark small {
+    display: none;
+  }
+
+  .desktop-navigation {
+    display: none;
+  }
+
+  .mobile-navigation {
+    display: block;
+  }
+
+  .mobile-navigation > summary {
+    cursor: pointer;
+    list-style: none;
+    border: 1px solid var(--color-text);
+    padding: 0.55rem 0.7rem;
+    font-size: 0.67rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .mobile-navigation > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .mobile-navigation > nav {
     position: absolute;
-    inset: 0;
-    border-radius: 0.5rem;
-    padding: 1px;
-    background: var(--gradient-purple);
-    -webkit-mask: 
-      linear-gradient(#fff 0 0) content-box, 
-      linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    z-index: -1;
+    z-index: 40;
+    top: 100%;
+    right: 0;
+    left: 0;
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-card);
+    box-shadow: 0 1rem 2rem rgba(9, 24, 25, 0.16);
   }
 
-  /* Blur reveal animation for title letters */
-  @keyframes blurFadeIn {
-    0% {
-      opacity: 0;
-      filter: blur(10px);
-    }
-    100% {
-      opacity: 1;
-      filter: blur(0);
-    }
+  .mobile-navigation > nav > a {
+    display: block;
+    border-bottom: 1px solid var(--color-border);
+    padding: 1rem 1.25rem;
+    font-family: var(--font-editorial);
+    font-size: 1.15rem;
+    text-decoration: none;
   }
 
-  .title-letter {
-    opacity: 0;
-    display: inline-block;
-    animation: blurFadeIn 0.8s ease-out forwards;
-    animation-delay: var(--delay);
+  .mobile-navigation-footer {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.8rem 1.25rem;
+    font-size: 0.72rem;
   }
-  
-  .subtitle-word {
-    opacity: 0;
-    display: inline-block;
-    margin-right: 0.35em;
-    animation: blurFadeIn 0.6s ease-out forwards; /* Slightly faster animation */
-    animation-delay: var(--delay);
+
+  .mobile-navigation-footer a[aria-current='page'] {
+    color: var(--color-accent);
+    font-weight: 700;
+  }
+
+  .mobile-navigation-footer .theme-toggle {
+    margin-left: auto;
+  }
+
+  .site-main {
+    padding-block: 1.8rem 3.5rem;
+  }
+
+  .site-footer-inner {
+    flex-direction: column;
+    gap: 1.6rem;
+  }
+
+  .footer-navigation {
+    justify-content: flex-start;
+  }
+
+  .footer-colophon {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,7 @@
   --color-table-border: #b9b1a2;
   --color-table-row-alt: #ebe4d8;
   --color-table-text: #fffaf1;
+  --logo-filter: none;
   --font-editorial:
     'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia,
     serif;
@@ -44,6 +45,7 @@ html.dark-theme {
   --color-table-border: #4c5b59;
   --color-table-row-alt: #192728;
   --color-table-text: #f6f0e6;
+  --logo-filter: brightness(0) invert(1);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -64,6 +66,7 @@ html.dark-theme {
     --color-table-border: #4c5b59;
     --color-table-row-alt: #192728;
     --color-table-text: #f6f0e6;
+    --logo-filter: brightness(0) invert(1);
   }
 }
 
@@ -160,8 +163,11 @@ html.dark-theme {
     text-decoration: none;
   }
 
-  .site-brand img {
+  .site-brand img,
+  .footer-brand img {
     flex: none;
+    filter: var(--logo-filter);
+    transition: filter 180ms ease;
   }
 
   .site-wordmark {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -162,7 +162,6 @@ html.dark-theme {
 
   .site-brand img {
     flex: none;
-    border: 1px solid var(--color-border);
   }
 
   .site-wordmark {
@@ -304,10 +303,6 @@ html.dark-theme {
     max-width: 34rem;
     align-items: flex-start;
     gap: 0.9rem;
-  }
-
-  .footer-brand img {
-    border: 1px solid var(--color-border);
   }
 
   .footer-brand strong {


### PR DESCRIPTION
## Qué cambia

- reemplaza la apariencia genérica de blog tecnológico por una dirección editorial inspirada en archivos documentales
- añade una marca vectorial DOF-RAG y un favicon coherente
- reconstruye la portada con hero, datos del corpus, cuaderno de investigación, temas y RSS
- rediseña las tarjetas de publicaciones y la navegación para desktop y móvil
- incorpora tema claro/oscuro y respeta preferencias de movimiento reducido
- actualiza textos equivalentes en español e inglés y el manifiesto web

## Por qué

El sitio necesitaba una identidad que comunicara mejor la combinación de investigación técnica, documentación pública y contenido jurídico. Esta propuesta privilegia rigor editorial, legibilidad y una personalidad propia sin parecer un portal gubernamental tradicional.

## Impacto

La portada y la navegación cambian visualmente en ambos idiomas. El contenido existente, las rutas del blog y el despliegue estático en GitHub Pages se conservan.

## Validación

- `pnpm run check` — 0 errores
- `pnpm run build` — 135 páginas estáticas generadas correctamente
- `git diff --check` — sin problemas de whitespace
