### PR TITLE
Add public review page for eval v4

### DIFF
--- a/src/content/blog/es/eval-v4-evidencia-retrieval.md
+++ b/src/content/blog/es/eval-v4-evidencia-retrieval.md
@@ -193,6 +193,6 @@ El cambio importante de v4 no es el tamaño —42 preguntas son pocas— sino el
 
 ## Ayúdanos a revisar el conjunto
 
-Publicamos una [edición de revisión de las 42 preguntas](/es/evals/v4) con sus respuestas, fechas de corte y citas de referencia. Buscamos observaciones sobre preguntas ambiguas, respuestas incompletas, problemas de vigencia y fuentes alternativas que también deberían aceptarse.
+Publicamos una [edición de revisión de las 42 preguntas](/dof-rag-website/es/evals/v4) con sus respuestas, fechas de corte y citas de referencia. Buscamos observaciones sobre preguntas ambiguas, respuestas incompletas, problemas de vigencia y fuentes alternativas que también deberían aceptarse.
 
 No hace falta revisar el conjunto completo. Una corrección bien sustentada sobre una sola pregunta es útil y quedará registrada antes de que v4 se convierta en una puerta de calidad.

--- a/src/content/blog/es/eval-v4-evidencia-retrieval.md
+++ b/src/content/blog/es/eval-v4-evidencia-retrieval.md
@@ -190,3 +190,9 @@ V4 es un piloto, no un examen definitivo. Antes de usar un número suyo para apr
 4. **Más juicios de relevancia.** Algunas preguntas admiten varias fuentes válidas. El set debe registrar relevancia graduada y documentos alternativos, no forzar una única fuente correcta cuando la tarea no lo requiere.
 
 El cambio importante de v4 no es el tamaño —42 preguntas son pocas— sino el contrato. Una respuesta buena necesita fuentes completas, pasajes concretos y capacidad para rechazar una premisa incorrecta. Ahora podemos medir esas tres cosas por separado y observar dónde falla cada etapa del buscador.
+
+## Ayúdanos a revisar el conjunto
+
+Publicamos una [edición de revisión de las 42 preguntas](/es/evals/v4) con sus respuestas, fechas de corte y citas de referencia. Buscamos observaciones sobre preguntas ambiguas, respuestas incompletas, problemas de vigencia y fuentes alternativas que también deberían aceptarse.
+
+No hace falta revisar el conjunto completo. Una corrección bien sustentada sobre una sola pregunta es útil y quedará registrada antes de que v4 se convierta en una puerta de calidad.

--- a/src/data/eval-v4-review.json
+++ b/src/data/eval-v4-review.json
@@ -1,0 +1,1174 @@
+[
+  {
+    "id": "SP-001",
+    "category": "single_passage",
+    "question": "¿Cuáles son los salarios mínimos generales diarios que rigen en 2026 para la Zona del Salario Mínimo General y la Zona Libre de la Frontera Norte?",
+    "persona": "recursos_humanos",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "$315.04 por jornada diaria en la Zona del Salario Mínimo General y $440.87 en la Zona Libre de la Frontera Norte, vigentes desde el 1 de enero de 2026.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651143,
+        "publication_date": "2025-12-09",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Los salarios mínimos generales que tendrán vigencia a partir del 1º de enero de 2026, reflejan un incremento de la siguiente manera: En 13.0% en la Zona del Salario Mínimo General (ZSMG), con lo que será de 315.04 pesos por jornada diaria de trabajo; que se compone de 17.01 pesos de MIR más un aumento por fijación de 6.5%. En 5.0% en la Zona Libre de la Frontera Norte (ZLFN), con lo que será de 440.87 pesos por jornada diaria de trabajo. En este caso no se aplica el MIR."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "SP-002",
+    "category": "single_passage",
+    "question": "¿Cuál fue el tipo de cambio para solventar obligaciones en dólares obtenido por Banco de México el 9 de agosto de 2006?",
+    "persona": "tesoreria",
+    "difficulty": "easy",
+    "as_of": "2006-08-10",
+    "answerability": "answerable",
+    "reference_answer": "$10.8386 pesos mexicanos por dólar de los Estados Unidos.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 165057,
+        "publication_date": "2006-08-10",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "el tipo de cambio citado obtenido el día de hoy conforme al procedimiento establecido en el numeral 1 de las Disposiciones mencionadas, fue de $10.8386 M.N. (DIEZ PESOS CON OCHO MIL TRESCIENTOS OCHENTA Y SEIS DIEZMILESIMOS MONEDA NACIONAL) por un dólar de los EE.UU.A."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "SP-003",
+    "category": "single_passage",
+    "question": "¿Cómo define la NOM-035-STPS-2018 los factores de riesgo psicosocial?",
+    "persona": "recursos_humanos",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Son factores que pueden provocar trastornos de ansiedad, alteraciones no orgánicas del ciclo sueño-vigilia y estrés grave o de adaptación, derivados de las funciones, jornada, acontecimientos traumáticos severos o violencia laboral por el trabajo desarrollado.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Factores de Riesgo Psicosocial: Aquellos que pueden provocar trastornos de ansiedad, no orgánicos del ciclo sueño-vigilia y de estrés grave y de adaptación, derivado de la naturaleza de las funciones del puesto de trabajo, el tipo de jornada de trabajo y la exposición a acontecimientos traumáticos severos o a actos de violencia laboral al trabajador, por el trabajo desarrollado."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "SP-004",
+    "category": "single_passage",
+    "question": "¿Cuál es el mínimo de días continuos de vacaciones que debe disfrutar una persona trabajadora conforme al artículo 78 reformado en 2022?",
+    "persona": "trabajador",
+    "difficulty": "easy",
+    "as_of": "2023-01-01",
+    "answerability": "answerable",
+    "reference_answer": "Por lo menos doce días continuos; la persona trabajadora puede distribuir el periodo en la forma y tiempo que requiera.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 586299,
+        "publication_date": "2022-12-27",
+        "section": "VES",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Artículo 78.- Del total del periodo que le corresponda conforme a lo previsto en el artículo 76 de esta Ley, la persona trabajadora disfrutará de doce días de vacaciones continuos, por lo menos. Dicho periodo, a potestad de la persona trabajadora podrá ser distribuido en la forma y tiempo que así lo requiera."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "SP-005",
+    "category": "single_passage",
+    "question": "¿Cuántos inmuebles y qué superficie comprende la expropiación para los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya decretada en abril de 2026?",
+    "persona": "periodista",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Comprende 14 inmuebles de propiedad privada con una superficie total de 48,661.703 m².",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Se expropia por causa de utilidad pública la superficie de 48,661.703 m² (cuarenta y ocho mil seiscientos sesenta y uno punto setecientos tres metros cuadrados), a favor de la Federación, por conducto de Tren Maya, S.A. de C.V., para la ejecución de los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya, correspondiente a 14 (catorce) inmuebles de propiedad privada."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "SP-006",
+    "category": "single_passage",
+    "question": "¿Cuál fue el INPC de diciembre de 2025 y qué variación tuvo respecto de noviembre de 2025?",
+    "persona": "contador",
+    "difficulty": "easy",
+    "as_of": "2026-01-09",
+    "answerability": "answerable",
+    "reference_answer": "El INPC de diciembre de 2025 fue 143.042, una variación de 0.28% respecto de noviembre, cuyo índice fue 142.645.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "el Índice Nacional de Precios al Consumidor del mes de diciembre de 2025 es 143.042. Esta cifra representa una variación de 0.28 por ciento respecto del índice correspondiente al mes de noviembre de 2025, que fue de 142.645."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-001",
+    "category": "list_enumeration",
+    "question": "¿Qué obligaciones de identificación y evaluación asigna la NOM-035 a centros con hasta 15, entre 16 y 50, y con más de 50 trabajadores?",
+    "persona": "recursos_humanos",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Hasta 15 trabajadores: no les aplican los numerales 5.2 ni 5.3, de modo que la NOM no les exige identificación o evaluación. Entre 16 y 50: identificar y analizar los factores de riesgo psicosocial de todos los trabajadores. Más de 50: identificar y analizar esos factores y evaluar el entorno organizacional, con posibilidad de usar una muestra representativa.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "a) Para centros de trabajo en los que laboren hasta quince trabajadores deberán cumplir con lo dispuesto por los numerales 5.1, 5.4, 5.5, 5.7, 8.1 y 8.2 de la presente Norma; b) Para centros de trabajo en los que laboren entre dieciséis y cincuenta trabajadores deberán cumplir con los numerales 5.1, 5.2, del 5.4 al 5.8, 7.1, inciso a), 7.2, del 7.4 al 7.9, y el Capítulo 8 de esta Norma, y c) Para centros de trabajo en los que laboren más de 50 trabajadores deberán cumplir con los numerales 5.1, del 5.3 al 5.8, 7.1, inciso b), del 7.2 al 7.9 y el Capítulo 8 de la presente Norma."
+          },
+          {
+            "quote": "a) Los centros de trabajo que tengan entre 16 y 50 trabajadores, únicamente deberán realizar la identificación y análisis de los factores de riesgo psicosocial, incluyendo a todos los trabajadores (ver Guía de referencia II), y b) Los centros de trabajo que tengan más de 50 trabajadores, deberán realizar la identificación y análisis de los factores de riesgo psicosocial y la evaluación del entorno organizacional, éstas se podrán realizar con una muestra representativa conforme a lo señalado en la Guía de referencia III, en el numeral III.1."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-002",
+    "category": "list_enumeration",
+    "question": "¿Cuáles son los valores diario, mensual y anual de la UMA para 2026?",
+    "persona": "contador",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "$117.31 diarios, $3,566.22 mensuales y $42,794.64 anuales.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $117.31 pesos mexicanos, el mensual es de $3,566.22 pesos mexicanos y el valor anual $42,794.64 pesos mexicanos, los cuales estarán vigentes a partir del 1º de febrero de 2026."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-003",
+    "category": "list_enumeration",
+    "question": "¿En qué municipios se ubican los 14 inmuebles expropiados para el Proyecto Tren Maya en abril de 2026?",
+    "persona": "periodista",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Candelaria, Champotón y Campeche, en Campeche; Tenosique, en Tabasco; Umán, en Yucatán; y Othón P. Blanco, Puerto Morelos, Solidaridad, Tulum y Felipe Carrillo Puerto, en Quintana Roo.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "correspondiente a 14 (catorce) inmuebles de propiedad privada, ubicados en los municipios de Candelaria, Champotón y Campeche en el estado de Campeche; Tenosique en el estado de Tabasco; Umán en el estado de Yucatán; Othón P. Blanco, Puerto Morelos, Solidaridad, Tulum y Felipe Carrillo Puerto en el estado de Quintana Roo."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-004",
+    "category": "list_enumeration",
+    "question": "¿Cuáles son los cuatro ejes generales y los tres ejes transversales del Plan Nacional de Desarrollo 2025-2030?",
+    "persona": "servidor_publico",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Ejes generales: Gobernanza con justicia y participación ciudadana; Desarrollo con bienestar y humanismo; Economía moral y trabajo; Desarrollo sustentable. Ejes transversales: Igualdad sustantiva y derechos de las mujeres; Innovación pública para el desarrollo tecnológico nacional; Derechos de los pueblos y comunidades indígenas y afromexicanas.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Este PND se articula sobre cuatro ejes generales y tres ejes transversales que estructuran la política pública en su conjunto. Gobernanza con justicia y participación ciudadana. Desarrollo con bienestar y humanismo. Economía moral y trabajo. Desarrollo sustentable. Igualdad sustantiva y derechos de las mujeres. Innovación pública para el desarrollo tecnológico nacional. Derechos de los pueblos y comunidades indígenas y afromexicanas."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-005",
+    "category": "list_enumeration",
+    "question": "¿Qué tres elementos mínimos debía considerar la ley nacional de simplificación administrativa y digitalización ordenada por la reforma constitucional de abril de 2025?",
+    "persona": "servidor_publico",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Un modelo nacional de simplificación y digitalización; una autoridad nacional en la materia; y herramientas de simplificación y digitalización de trámites y servicios.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "1. Un modelo nacional de simplificación y digitalización de trámites y servicios; 2. Establecer la autoridad nacional en materia de simplificación administrativa y digitalización de trámites y servicios, buenas prácticas regulatorias, desarrollo y fortalecimiento de capacidades tecnológicas y públicas, y 3. Prever herramientas de simplificación y digitalización de trámites y servicios."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "LI-006",
+    "category": "list_enumeration",
+    "question": "¿Cuáles son los siete objetos que enumera el artículo 3 de la Ley General de Aguas publicada en diciembre de 2025?",
+    "persona": "consultor_ambiental",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Definir el contenido del derecho humano al agua; promoverlo, respetarlo, protegerlo y garantizarlo; establecer instancias, instrumentos y procedimientos de concurrencia gubernamental; definir participación ciudadana; garantizar servicios públicos de agua y saneamiento; establecer bases de políticas con perspectivas de equidad; y promover la cultura del agua.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651357,
+        "publication_date": "2025-12-11",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Artículo 3. Es objeto de esta Ley: I. Definir el contenido del derecho humano al agua y establecer las disposiciones que garantizan su acceso equitativo y su uso sustentable; II. Promover, respetar, proteger y garantizar el derecho humano al agua para consumo personal y doméstico, su acceso, disposición y saneamiento acorde con la Constitución y los tratados internacionales en materia de derechos humanos de los que el Estado mexicano sea parte; III. Establecer las instancias, instrumentos y procedimientos para la participación de la Federación, entidades federativas y municipios en la tutela del derecho humano al agua; IV. Definir los mecanismos, instrumentos e instancias de participación ciudadana en el acceso equitativo y uso sustentable del agua para consumo personal y doméstico; V. Garantizar el acceso equitativo y sustentable a los servicios públicos de agua y saneamiento, así como fortalecer las bases de su operación;"
+          },
+          {
+            "quote": "VI. Establecer las bases de las políticas públicas que garanticen las perspectivas de género, discapacidad, interculturalidad, intergeneracional, ecosistémica y etaria, para fomentar condiciones de equidad en la gestión y gobernanza del agua, y VII. Promover la cultura del agua."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-001",
+    "category": "temporal_transitorio",
+    "question": "¿En qué fechas entraron en vigor la regla general y las obligaciones diferidas de la NOM-035-STPS-2018?",
+    "persona": "recursos_humanos",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "La regla general entró en vigor el 23 de octubre de 2019, un año después de su publicación. Los numerales 5.2, 5.3, 5.6, 5.8, 8.3, 8.4, 8.5 y el capítulo 7 entraron en vigor el 23 de octubre de 2020, dos años después.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "PRIMERO. La presente Norma Oficial Mexicana entrará en vigor al año siguiente de su publicación en el Diario Oficial de la Federación. SEGUNDO. Lo dispuesto por los numerales 5.2, 5.3, 5.6, 5.8, 8.3, 8.4, 8.5, y Capítulo 7, entrará en vigor a los dos años siguientes a su publicación en el Diario Oficial de la Federación."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-002",
+    "category": "temporal_transitorio",
+    "question": "¿Desde qué fecha estuvieron vigentes los valores de la UMA de 2026 publicados el 9 de enero?",
+    "persona": "contador",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Desde el 1 de febrero de 2026.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $117.31 pesos mexicanos, el mensual es de $3,566.22 pesos mexicanos y el valor anual $42,794.64 pesos mexicanos, los cuales estarán vigentes a partir del 1º de febrero de 2026."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-003",
+    "category": "temporal_transitorio",
+    "question": "¿Desde qué fecha rigen los salarios mínimos generales fijados para 2026?",
+    "persona": "recursos_humanos",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Desde el 1 de enero de 2026.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651143,
+        "publication_date": "2025-12-09",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Los salarios mínimos generales que tendrán vigencia a partir del 1º de enero de 2026, reflejan un incremento de la siguiente manera."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-004",
+    "category": "temporal_transitorio",
+    "question": "¿Cuándo entró en vigor la Ley General de Aguas publicada el 11 de diciembre de 2025 y qué plazo tuvieron las entidades federativas para armonizar sus normas?",
+    "persona": "abogado",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Entró en vigor el 12 de diciembre de 2025. Las entidades federativas tuvieron un máximo de 180 días naturales desde su entrada en vigor para armonizar sus disposiciones.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651357,
+        "publication_date": "2025-12-11",
+        "section": "MAT",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Primero.- La presente Ley entrará en vigor el día siguiente al de su publicación en el Diario Oficial de la Federación. Segundo.- Las entidades federativas deben armonizar sus disposiciones jurídicas con lo dispuesto en la presente Ley, en un plazo que no exceda de ciento ochenta días naturales a partir de su entrada en vigor."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-005",
+    "category": "temporal_transitorio",
+    "question": "¿Cuándo entró en vigor la reforma de vacaciones a los artículos 76 y 78 de la Ley Federal del Trabajo publicada el 27 de diciembre de 2022?",
+    "persona": "trabajador",
+    "difficulty": "easy",
+    "as_of": "2023-01-01",
+    "answerability": "answerable",
+    "reference_answer": "El 1 de enero de 2023.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 586299,
+        "publication_date": "2022-12-27",
+        "section": "VES",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Primero.- El presente Decreto entrará en vigor el 1.° de enero de 2023, o al día siguiente de su publicación en el Diario Oficial de la Federación, si esta fuera en el año 2023."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TE-006",
+    "category": "temporal_transitorio",
+    "question": "¿Cuándo entró en vigor la reforma constitucional de simplificación administrativa publicada el 15 de abril de 2025 y qué plazo dio al Congreso para expedir la ley nacional?",
+    "persona": "servidor_publico",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Entró en vigor el 16 de abril de 2025. El Congreso debía expedir la legislación dentro de un plazo no mayor de 90 días naturales siguientes a la entrada en vigor.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "answer",
+        "evidence": [
+          {
+            "quote": "Primero.- El presente Decreto entrará en vigor al día siguiente de su publicación en el Diario Oficial de la Federación. Segundo.- En un plazo que no excederá de noventa días naturales siguientes a la entrada en vigor del presente Decreto, el Congreso de la Unión expedirá la legislación a que se refiere el artículo 73, fracción XXIX-Y, de esta Constitución."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-001",
+    "category": "cross_reference",
+    "question": "El segundo transitorio de la NOM-035 difirió la entrada en vigor del numeral 5.2: ¿qué obligación contiene ese numeral y a qué centros de trabajo aplica?",
+    "persona": "recursos_humanos",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Obliga a identificar y analizar los factores de riesgo psicosocial conforme a los numerales 7.1(a) y 7.2, y aplica a centros con entre 16 y 50 trabajadores. Entró en vigor dos años después de la publicación de la NOM.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "source_and_target",
+        "evidence": [
+          {
+            "quote": "Lo dispuesto por los numerales 5.2, 5.3, 5.6, 5.8, 8.3, 8.4, 8.5, y Capítulo 7, entrará en vigor a los dos años siguientes a su publicación en el Diario Oficial de la Federación."
+          },
+          {
+            "quote": "5.2 Identificar y analizar los factores de riesgo psicosocial, de acuerdo con lo establecido en los numerales 7.1, inciso a), y 7.2, de esta Norma, tratándose de centros de trabajo que tengan entre 16 y 50 trabajadores."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-002",
+    "category": "cross_reference",
+    "question": "Los numerales 8.3, 8.4 y 8.5 citados por el segundo transitorio de la NOM-035, ¿qué exigen cuando una evaluación determina que se necesitan acciones de control?",
+    "persona": "recursos_humanos",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Exigen implementar un programa de atención que identifique áreas o trabajadores, medidas, fechas, control de avances, evaluación posterior y responsable; las acciones pueden operar en niveles organizacional, grupal e individual.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "source_and_target",
+        "evidence": [
+          {
+            "quote": "Lo dispuesto por los numerales 5.2, 5.3, 5.6, 5.8, 8.3, 8.4, 8.5, y Capítulo 7, entrará en vigor a los dos años siguientes a su publicación en el Diario Oficial de la Federación."
+          },
+          {
+            "quote": "8.3 Los centros de trabajo cuyo resultado de las evaluaciones a que se refieren los numerales 7.1 al 7.4, conforme a los criterios establecidos en el método aplicado, determinen la necesidad de desarrollar acciones de control, éstas se deberán implementar a través de un Programa que cumpla con lo previsto por el numeral 8.4 de la presente Norma. 8.4 El Programa para la atención de los factores de riesgo psicosocial, y en su caso, para propiciar un entorno organizacional favorable y prevenir actos de violencia laboral deberá contener: a) Las áreas de trabajo y/o los trabajadores sujetos al programa; b) El tipo de acciones y las medidas de control que deberán adoptarse; c) Las fechas programadas para su realización; d) El control de los avances de la implementación del programa; e) La evaluación posterior a la aplicación de las medidas de control, en su caso, y f) El responsable de su ejecución."
+          },
+          {
+            "quote": "8.5 El tipo de acciones deberán realizarse, según aplique, en los niveles siguientes: a) Primer nivel: Las acciones se centran en el plano organizacional e implican actuar sobre la política de prevención de riesgos psicosociales del centro de trabajo, la organización del trabajo, las acciones o medios para: disminuir los efectos de los factores de riesgo psicosocial, prevenir la violencia laboral y propiciar el entorno organizacional favorable."
+          },
+          {
+            "quote": "b) Segundo nivel: Las acciones se orientan al plano grupal e implica actuar en la interrelación de los trabajadores o grupos de ellos y la organización del trabajo; su actuación se centra en el tiempo de trabajo, el comportamiento y las interacciones personales, se basan en proporcionar información al trabajador, así como en la sensibilización, (contempla temas como: manejo de conflictos, trabajo en equipo, orientación a resultados, liderazgo, comunicación asertiva, administración del tiempo de trabajo, entre otros), y reforzar el apoyo social, y/o"
+          },
+          {
+            "quote": "c) Tercer nivel: Las acciones se enfocan al plano individual; es decir, se desarrolla cuando se comprueba que existen signos y/o síntomas que denotan alteraciones en la salud, se incluyen intervenciones de tipo clínico o terapéutico."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-003",
+    "category": "cross_reference",
+    "question": "¿Qué procedimiento del artículo 11 de la Ley de Expropiación invoca el decreto del Tren Maya y qué puede controvertirse mediante él?",
+    "persona": "abogado",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Las personas interesadas pueden acudir al procedimiento judicial dentro de los diez días hábiles siguientes a la notificación del decreto, únicamente para controvertir el monto de la indemnización.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "source_and_resolution",
+        "evidence": [
+          {
+            "quote": "Dentro de los diez días hábiles siguientes a la notificación de este decreto, las personas interesadas podrán acudir al procedimiento judicial a que se refiere el artículo 11 de la Ley de Expropiación, con el único objeto de controvertir el monto de la indemnización."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-004",
+    "category": "cross_reference",
+    "question": "¿Qué método del artículo 4 de la Ley para determinar el valor de la UMA reprodujo el aviso del INEGI para calcular los valores de 2026?",
+    "persona": "contador",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "El valor diario es el valor del año anterior multiplicado por uno más la variación interanual del INPC de diciembre; el mensual es el diario por 30.4; y el anual es el mensual por 12.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "source_and_resolution",
+        "evidence": [
+          {
+            "quote": "Que atendiendo al procedimiento establecido en el artículo 4 de la Ley para determinar el valor de la Unidad de Medida y Actualización, se utiliza el siguiente método para actualizar el valor de la Unidad de Medida y Actualización: 1. El valor diario se determinará multiplicando el valor diario de la Unidad de Medida y Actualización del año inmediato anterior por el resultado de la suma de uno más la variación interanual del Índice Nacional de Precios al Consumidor del mes de diciembre del año inmediato anterior. 2. El valor mensual será el producto de multiplicar el valor diario de la Unidad de Medida y Actualización por 30.4. 3. El valor anual será el producto de multiplicar el valor mensual de la Unidad de Medida y Actualización por 12."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-005",
+    "category": "cross_reference",
+    "question": "¿Qué facultad ejerció la Cámara de Diputados con fundamento en el artículo 74, fracción VII, constitucional en el decreto del PND 2025-2030?",
+    "persona": "abogado",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "Aprobó el Plan Nacional de Desarrollo 2025-2030 enviado por la titular del Ejecutivo el 28 de febrero de 2025 y ordenó remitir el acuerdo y el plan al Ejecutivo para su publicación e implementación.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "source_and_resolution",
+        "evidence": [
+          {
+            "quote": "LA CÁMARA DE DIPUTADOS DEL HONORABLE CONGRESO DE LA UNIÓN, CON FUNDAMENTO EN LA FRACCIÓN VII DEL ARTÍCULO 74 DE LA CONSTITUCIÓN POLÍTICA DE LOS ESTADOS UNIDOS MEXICANOS, DECRETA: Primero.- La Cámara de Diputados del Honorable Congreso de la Unión aprueba el Plan Nacional de Desarrollo 2025-2030 enviado por la Titular del Ejecutivo Federal el día 28 de febrero de 2025, por incluir y cumplir a cabalidad los fines del proyecto nacional establecidos en la Constitución Política de los Estados Unidos Mexicanos. Segundo.- Remítanse al Ejecutivo Federal el presente Acuerdo y el Plan Nacional de Desarrollo 2025-2030, para su publicación en el Diario Oficial de la Federación y su implementación integral."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "CR-006",
+    "category": "cross_reference",
+    "question": "¿Qué derecho constitucional desarrolla la Ley General de Aguas al declararse reglamentaria del artículo 4o., párrafo octavo?",
+    "persona": "abogado",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "El derecho humano al acceso, disposición y saneamiento del agua para consumo personal y doméstico.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651357,
+        "publication_date": "2025-12-11",
+        "section": "MAT",
+        "role": "source_and_resolution",
+        "evidence": [
+          {
+            "quote": "La presente Ley es reglamentaria del artículo 4o., párrafo octavo, de la Constitución Política de los Estados Unidos Mexicanos en materia del derecho humano al acceso, disposición y saneamiento del agua para consumo personal y doméstico."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-001",
+    "category": "multi_document",
+    "question": "¿Cómo cambiaron los salarios mínimos generales de 2025 a 2026 en la zona general y en la Zona Libre de la Frontera Norte?",
+    "persona": "recursos_humanos",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "La zona general pasó de $278.80 a $315.04 diarios, un aumento de $36.24. La Zona Libre de la Frontera Norte pasó de $419.88 a $440.87, un aumento de $20.99.",
+    "unanswerable_reason": null,
+    "required_hops": 2,
+    "gold_documents": [
+      {
+        "document_id": 631042,
+        "publication_date": "2024-12-19",
+        "section": "MAT",
+        "role": "2025_values",
+        "evidence": [
+          {
+            "quote": "Los salarios mínimos generales que tendrán vigencia a partir del 1º de enero de 2025, se incrementarán en 12% en las dos zonas descritas en el primer resolutivo, por tanto, serán de 419.88 pesos diarios por jornada diaria de trabajo en el área geográfica de la Zona Libre de la Frontera Norte (ZLFN), cuyo incremento se compone de 19.36 pesos de MIR más un aumento por fijación del 6.5%, y para La Zona del Salario Mínimo General (ZSMG) el salario mínimo será de 278.80 pesos diarios, por jornada diaria de trabajo, cuyo incremento se compone de 12.85 pesos de MIR más 6.5% de aumento por fijación."
+          }
+        ]
+      },
+      {
+        "document_id": 651143,
+        "publication_date": "2025-12-09",
+        "section": "MAT",
+        "role": "2026_values",
+        "evidence": [
+          {
+            "quote": "En 13.0% en la Zona del Salario Mínimo General (ZSMG), con lo que será de 315.04 pesos por jornada diaria de trabajo; que se compone de 17.01 pesos de MIR más un aumento por fijación de 6.5%. En 5.0% en la Zona Libre de la Frontera Norte (ZLFN), con lo que será de 440.87 pesos por jornada diaria de trabajo. En este caso no se aplica el MIR."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-002",
+    "category": "multi_document",
+    "question": "¿Cómo cambiaron los valores diario, mensual y anual de la UMA de 2025 a 2026?",
+    "persona": "contador",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "La UMA diaria pasó de $113.14 a $117.31; la mensual de $3,439.46 a $3,566.22; y la anual de $41,273.52 a $42,794.64.",
+    "unanswerable_reason": null,
+    "required_hops": 2,
+    "gold_documents": [
+      {
+        "document_id": 631807,
+        "publication_date": "2025-01-10",
+        "section": "MAT",
+        "role": "2025_values",
+        "evidence": [
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $113.14 pesos mexicanos, el mensual es de $3,439.46 pesos mexicanos y el valor anual $41,273.52 pesos mexicanos, los cuales estarán vigentes a partir del 1º de febrero de 2025."
+          }
+        ]
+      },
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "2026_values",
+        "evidence": [
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $117.31 pesos mexicanos, el mensual es de $3,566.22 pesos mexicanos y el valor anual $42,794.64 pesos mexicanos, los cuales estarán vigentes a partir del 1º de febrero de 2026."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-003",
+    "category": "multi_document",
+    "question": "¿Cómo cambió el tipo de cambio de Banco de México entre el valor obtenido el 8 y el obtenido el 9 de agosto de 2006?",
+    "persona": "tesoreria",
+    "difficulty": "medium",
+    "as_of": "2006-08-10",
+    "answerability": "answerable",
+    "reference_answer": "Bajó de $10.9113 por dólar el 8 de agosto a $10.8386 el 9 de agosto, una disminución de $0.0727 por dólar.",
+    "unanswerable_reason": null,
+    "required_hops": 2,
+    "gold_documents": [
+      {
+        "document_id": 165008,
+        "publication_date": "2006-08-09",
+        "section": "MAT",
+        "role": "august_8_value",
+        "evidence": [
+          {
+            "quote": "el tipo de cambio citado obtenido el día de hoy conforme al procedimiento establecido en el numeral 1 de las Disposiciones mencionadas, fue de $10.9113 M.N. (DIEZ PESOS CON NUEVE MIL CIENTO TRECE DIEZMILESIMOS MONEDA NACIONAL) por un dólar de los EE.UU.A."
+          }
+        ]
+      },
+      {
+        "document_id": 165057,
+        "publication_date": "2006-08-10",
+        "section": "MAT",
+        "role": "august_9_value",
+        "evidence": [
+          {
+            "quote": "el tipo de cambio citado obtenido el día de hoy conforme al procedimiento establecido en el numeral 1 de las Disposiciones mencionadas, fue de $10.8386 M.N. (DIEZ PESOS CON OCHO MIL TRESCIENTOS OCHENTA Y SEIS DIEZMILESIMOS MONEDA NACIONAL) por un dólar de los EE.UU.A."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-004",
+    "category": "multi_document",
+    "question": "¿Cuál fue la secuencia de publicaciones y plazos desde la declaratoria de utilidad pública hasta el decreto de expropiación de 14 inmuebles para el Tren Maya?",
+    "persona": "abogado",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "La declaratoria se publicó el 5 de enero de 2026 y por segunda vez el 6 de enero. Desde la notificación o segunda publicación hubo 15 días hábiles para manifestaciones y pruebas. El decreto de expropiación se publicó el 17 de abril y concedió 10 días hábiles desde su notificación para controvertir judicialmente sólo el monto de la indemnización.",
+    "unanswerable_reason": null,
+    "required_hops": 3,
+    "gold_documents": [
+      {
+        "document_id": 652468,
+        "publication_date": "2026-01-05",
+        "section": "MAT",
+        "role": "first_declaration",
+        "evidence": [
+          {
+            "quote": "Los interesados tendrán un plazo de quince días hábiles a partir de la notificación o de la segunda publicación en el Diario Oficial de la Federación de la presente Declaratoria, para manifestar ante la Unidad de Asuntos Jurídicos de la Secretaría de Desarrollo Agrario Territorial y Urbano, lo que a su derecho e interés convenga y presenten las pruebas que estimen pertinentes."
+          }
+        ]
+      },
+      {
+        "document_id": 652496,
+        "publication_date": "2026-01-06",
+        "section": "MAT",
+        "role": "second_declaration",
+        "evidence": [
+          {
+            "quote": "DECLARATORIA de causa de utilidad pública relativa a 48,661.703 metros cuadrados, correspondientes a 14 inmuebles de propiedad privada, en los municipios de Candelaria, Champotón y Campeche en el Estado de Campeche; Tenosique en el Estado de Tabasco; Umán en el Estado de Yucatán; Othón P. Blanco, Puerto Morelos, Solidaridad, Tulum y Felipe Carrillo Puerto en el Estado de Quintana Roo, que serán destinados para la construcción de obras de infraestructura pública relacionadas con el Proyecto Tren Maya (Segunda publicación)."
+          }
+        ]
+      },
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "expropriation_decree",
+        "evidence": [
+          {
+            "quote": "Dentro de los diez días hábiles siguientes a la notificación de este decreto, las personas interesadas podrán acudir al procedimiento judicial a que se refiere el artículo 11 de la Ley de Expropiación, con el único objeto de controvertir el monto de la indemnización."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-005",
+    "category": "multi_document",
+    "question": "¿Qué fundamento constitucional usó la Cámara de Diputados para aprobar los PND 2019-2024 y 2025-2030, y qué remitió al Ejecutivo en cada caso?",
+    "persona": "servidor_publico",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "En ambos casos invocó el artículo 74, fracción VII, constitucional. En 2019 remitió al Ejecutivo el informe de Parlamento Abierto y el trabajo de las comisiones; en 2025 ordenó remitir el acuerdo y el propio PND para publicación e implementación integral.",
+    "unanswerable_reason": null,
+    "required_hops": 2,
+    "gold_documents": [
+      {
+        "document_id": 514741,
+        "publication_date": "2019-07-12",
+        "section": "MAT",
+        "role": "pnd_2019",
+        "evidence": [
+          {
+            "quote": "LA CÁMARA DE DIPUTADOS, CON FUNDAMENTO EN LA FRACCIÓN VII DEL ARTÍCULO 74 DE LA CONSTITUCIÓN POLÍTICA DE LOS ESTADOS UNIDOS MEXICANOS, D E C R E T A: Artículo Primero.- Se aprueba el Plan Nacional de Desarrollo 2019-2024 por contener los fines del proyecto nacional establecidos en la Constitución Política de los Estados Unidos Mexicanos. Artículo Segundo.- Se remite al Ejecutivo Federal el informe de Parlamento Abierto y el trabajo desarrollado por las Comisiones de esta Cámara con motivo del análisis del Plan Nacional de Desarrollo 2019-2024, para su consideración y los efectos legales a que haya lugar."
+          }
+        ]
+      },
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "pnd_2025",
+        "evidence": [
+          {
+            "quote": "LA CÁMARA DE DIPUTADOS DEL HONORABLE CONGRESO DE LA UNIÓN, CON FUNDAMENTO EN LA FRACCIÓN VII DEL ARTÍCULO 74 DE LA CONSTITUCIÓN POLÍTICA DE LOS ESTADOS UNIDOS MEXICANOS, DECRETA: Primero.- La Cámara de Diputados del Honorable Congreso de la Unión aprueba el Plan Nacional de Desarrollo 2025-2030 enviado por la Titular del Ejecutivo Federal el día 28 de febrero de 2025, por incluir y cumplir a cabalidad los fines del proyecto nacional establecidos en la Constitución Política de los Estados Unidos Mexicanos. Segundo.- Remítanse al Ejecutivo Federal el presente Acuerdo y el Plan Nacional de Desarrollo 2025-2030, para su publicación en el Diario Oficial de la Federación y su implementación integral."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MD-006",
+    "category": "multi_document",
+    "question": "¿Cómo queda la cronología laboral formada por las dos fases de entrada en vigor de la NOM-035 y la reforma de vacaciones dignas?",
+    "persona": "recursos_humanos",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "answerable",
+    "reference_answer": "La NOM-035 entró en vigor en general el 23 de octubre de 2019 y sus obligaciones diferidas el 23 de octubre de 2020. La reforma a los artículos 76 y 78 de la Ley Federal del Trabajo entró en vigor el 1 de enero de 2023.",
+    "unanswerable_reason": null,
+    "required_hops": 2,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "nom_035",
+        "evidence": [
+          {
+            "quote": "PRIMERO. La presente Norma Oficial Mexicana entrará en vigor al año siguiente de su publicación en el Diario Oficial de la Federación. SEGUNDO. Lo dispuesto por los numerales 5.2, 5.3, 5.6, 5.8, 8.3, 8.4, 8.5, y Capítulo 7, entrará en vigor a los dos años siguientes a su publicación en el Diario Oficial de la Federación."
+          }
+        ]
+      },
+      {
+        "document_id": 586299,
+        "publication_date": "2022-12-27",
+        "section": "VES",
+        "role": "vacation_reform",
+        "evidence": [
+          {
+            "quote": "El presente Decreto entrará en vigor el 1.° de enero de 2023, o al día siguiente de su publicación en el Diario Oficial de la Federación, si esta fuera en el año 2023."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-001",
+    "category": "monitoring",
+    "question": "¿Qué valores de INPC y UMA publicó el INEGI en el DOF del 9 de enero de 2026?",
+    "persona": "contador",
+    "difficulty": "medium",
+    "as_of": "2026-01-09",
+    "answerability": "answerable",
+    "reference_answer": "Publicó el INPC de diciembre de 2025 en 143.042 y el quincenal de la segunda quincena de diciembre en 143.027; además, la UMA 2026: $117.31 diaria, $3,566.22 mensual y $42,794.64 anual.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "date_and_agency_match",
+        "evidence": [
+          {
+            "quote": "el Índice Nacional de Precios al Consumidor del mes de diciembre de 2025 es 143.042. Esta cifra representa una variación de 0.28 por ciento respecto del índice correspondiente al mes de noviembre de 2025, que fue de 142.645."
+          },
+          {
+            "quote": "el Instituto Nacional de Estadística y Geografía da a conocer que el Índice Nacional de Precios al Consumidor quincenal con base en la segunda quincena de julio de 2018 = 100, correspondiente a la segunda quincena de diciembre de 2025, es de 143.027."
+          },
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $117.31 pesos mexicanos, el mensual es de $3,566.22 pesos mexicanos y el valor anual $42,794.64 pesos mexicanos."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-002",
+    "category": "monitoring",
+    "question": "¿Qué valores publicó Banco de México el 10 de agosto de 2006 para el tipo de cambio del día anterior, el INPC de julio y la UDI del 18 de agosto?",
+    "persona": "tesoreria",
+    "difficulty": "hard",
+    "as_of": "2006-08-10",
+    "answerability": "answerable",
+    "reference_answer": "Tipo de cambio: $10.8386 por dólar; INPC de julio de 2006: 117.380 puntos; UDI del 18 de agosto de 2006: $3.687364.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 165057,
+        "publication_date": "2006-08-10",
+        "section": "MAT",
+        "role": "date_and_agency_match",
+        "evidence": [
+          {
+            "quote": "el tipo de cambio citado obtenido el día de hoy conforme al procedimiento establecido en el numeral 1 de las Disposiciones mencionadas, fue de $10.8386 M.N. (DIEZ PESOS CON OCHO MIL TRESCIENTOS OCHENTA Y SEIS DIEZMILESIMOS MONEDA NACIONAL) por un dólar de los EE.UU.A."
+          },
+          {
+            "quote": "el Indice Nacional de Precios al Consumidor de julio de 2006 es de 117.380 puntos. Dicho número representa un incremento de 0.27 por ciento respecto al índice correspondiente al mes de junio de 2006."
+          },
+          {
+            "quote": "18-agosto-2006 3.687364 19-agosto-2006 3.687623 20-agosto-2006 3.687883"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-003",
+    "category": "monitoring",
+    "question": "¿Qué publicó la Secretaría del Trabajo en el DOF del 23 de octubre de 2018 sobre riesgos psicosociales y cuál era su objetivo?",
+    "persona": "recursos_humanos",
+    "difficulty": "medium",
+    "as_of": "2018-10-23",
+    "answerability": "answerable",
+    "reference_answer": "Publicó la NOM-035-STPS-2018, cuyo objetivo es identificar, analizar y prevenir los factores de riesgo psicosocial y promover un entorno organizacional favorable.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 500086,
+        "publication_date": "2018-10-23",
+        "section": "MAT",
+        "role": "date_and_agency_match",
+        "evidence": [
+          {
+            "quote": "Establecer los elementos para identificar, analizar y prevenir los factores de riesgo psicosocial, así como para promover un entorno organizacional favorable en los centros de trabajo."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-004",
+    "category": "monitoring",
+    "question": "¿Qué publicó la Presidencia en la edición vespertina del DOF del 15 de abril de 2025 respecto del Plan Nacional de Desarrollo?",
+    "persona": "periodista",
+    "difficulty": "medium",
+    "as_of": "2025-04-15",
+    "answerability": "answerable",
+    "reference_answer": "Publicó el decreto por el que la Cámara de Diputados aprobó el Plan Nacional de Desarrollo 2025-2030 y ordenó remitirlo al Ejecutivo para su publicación e implementación integral, junto con el propio plan.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 637402,
+        "publication_date": "2025-04-15",
+        "section": "VES",
+        "role": "date_agency_edition_match",
+        "evidence": [
+          {
+            "quote": "Primero.- La Cámara de Diputados del Honorable Congreso de la Unión aprueba el Plan Nacional de Desarrollo 2025-2030 enviado por la Titular del Ejecutivo Federal el día 28 de febrero de 2025, por incluir y cumplir a cabalidad los fines del proyecto nacional establecidos en la Constitución Política de los Estados Unidos Mexicanos. Segundo.- Remítanse al Ejecutivo Federal el presente Acuerdo y el Plan Nacional de Desarrollo 2025-2030, para su publicación en el Diario Oficial de la Federación y su implementación integral."
+          },
+          {
+            "quote": "PLAN Nacional de Desarrollo 2025-2030. Condenamos el clasismo, el racismo, el machismo y cualquier forma de discriminación"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-005",
+    "category": "monitoring",
+    "question": "¿Qué resolución publicó la CONASAMI el 9 de diciembre de 2025 y qué dos montos generales fijó?",
+    "persona": "recursos_humanos",
+    "difficulty": "medium",
+    "as_of": "2025-12-09",
+    "answerability": "answerable",
+    "reference_answer": "Publicó la resolución que fijó los salarios mínimos generales y profesionales para 2026: $315.04 diarios en la zona general y $440.87 en la frontera norte.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651143,
+        "publication_date": "2025-12-09",
+        "section": "MAT",
+        "role": "date_and_agency_match",
+        "evidence": [
+          {
+            "quote": "RESOLUCIÓN del H. Consejo de Representantes de la Comisión Nacional de los Salarios Mínimos que fija los salarios mínimos generales y profesionales que habrán de regir a partir del 1 de enero de 2026."
+          },
+          {
+            "quote": "En 13.0% en la Zona del Salario Mínimo General (ZSMG), con lo que será de 315.04 pesos por jornada diaria de trabajo; que se compone de 17.01 pesos de MIR más un aumento por fijación de 6.5%. En 5.0% en la Zona Libre de la Frontera Norte (ZLFN), con lo que será de 440.87 pesos por jornada diaria de trabajo. En este caso no se aplica el MIR."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "MO-006",
+    "category": "monitoring",
+    "question": "¿Qué publicó la Presidencia el 17 de abril de 2026 sobre el Proyecto Tren Maya?",
+    "persona": "periodista",
+    "difficulty": "medium",
+    "as_of": "2026-04-17",
+    "answerability": "answerable",
+    "reference_answer": "Publicó el decreto de expropiación de 48,661.703 m² correspondientes a 14 inmuebles privados para los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya.",
+    "unanswerable_reason": null,
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "date_and_agency_match",
+        "evidence": [
+          {
+            "quote": "DECRETO por el que se expropia por causa de utilidad pública la superficie de 48,661.703 m² (cuarenta y ocho mil seiscientos sesenta y uno punto setecientos tres metros cuadrados), a favor de la Federación, por conducto de Tren Maya, S.A. de C.V., para la ejecución de los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya, correspondiente a 14 (catorce) inmuebles de propiedad privada, ubicados en los municipios de Candelaria, Champotón y Campeche en el estado de Campeche; Tenosique en el estado de Tabasco; Umán en el estado de Yucatán; Othón P. Blanco, Puerto Morelos, Solidaridad, Tulum y Felipe Carrillo Puerto en el estado de Quintana Roo."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-001",
+    "category": "negative_false_premise",
+    "question": "¿Qué establece el artículo 99 del decreto de expropiación del Tren Maya publicado el 17 de abril de 2026?",
+    "persona": "abogado",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "El decreto no contiene un artículo 99. Su parte resolutiva está formada por los puntos PRIMERO, SEGUNDO, TERCERO y CUARTO; por tanto, debe corregirse la premisa y no inventar el contenido solicitado.",
+    "unanswerable_reason": "nonexistent_article",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "DECRETO PRIMERO. Se expropia por causa de utilidad pública la superficie de 48,661.703 m² (cuarenta y ocho mil seiscientos sesenta y uno punto setecientos tres metros cuadrados), a favor de la Federación, por conducto de Tren Maya, S.A. de C.V., para la ejecución de los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya, correspondiente a 14 (catorce) inmuebles de propiedad privada, ubicados en los municipios de Candelaria, Champotón y Campeche en el estado de Campeche; Tenosique en el estado de Tabasco; Umán en el estado de Yucatán; Othón P. Blanco, Puerto Morelos, Solidaridad, Tulum y Felipe Carrillo Puerto en el estado de Quintana Roo. La expropiación incluye las construcciones e instalaciones que se encuentren en los bienes inmuebles y que formen parte de ellos. SEGUNDO. La Secretaría de Desarrollo Agrario, Territorial y Urbano procede a la ocupación inmediata de los bienes materia de esta expropiación. La interposición de cualquier medio de defensa no suspende la ocupación señalada en el párrafo anterior. TERCERO. Con motivo de la entrada en vigor del presente decreto, Tren Maya, S.A. de C.V., debe cubrir con su presupuesto autorizado el monto de la indemnización que en términos de ley deba pagarse a quienes acrediten su legítimo derecho, de conformidad con los avalúos que emitió el Instituto de Administración y Avalúos de Bienes Nacionales."
+          },
+          {
+            "quote": "CUARTO. Tren Maya, S.A. de C.V., en colaboración con las autoridades correspondientes, debe realizar todas las acciones legales necesarias respecto de aquellos actos jurídicos celebrados previo a la emisión del presente decreto."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-002",
+    "category": "negative_false_premise",
+    "question": "¿En qué fecha quedó abrogada por completo la Ley de Aguas Nacionales mediante el decreto del 11 de diciembre de 2025?",
+    "persona": "abogado",
+    "difficulty": "hard",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "La premisa es falsa. El decreto expidió la Ley General de Aguas y reformó, adicionó y derogó disposiciones concretas de la Ley de Aguas Nacionales; no abrogó por completo esta última. El transitorio sólo derogó las disposiciones que se opusieran al decreto.",
+    "unanswerable_reason": "incorrect_abrogation_claim",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651357,
+        "publication_date": "2025-12-11",
+        "section": "MAT",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "DECRETO por el que se expide la Ley General de Aguas y, se reforman, adicionan y derogan diversas disposiciones de la Ley de Aguas Nacionales."
+          },
+          {
+            "quote": "Primero. El presente Decreto entrará en vigor al día siguiente de su publicación en el Diario Oficial de la Federación. Segundo. Se derogan las disposiciones jurídicas que se opongan al presente Decreto."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-003",
+    "category": "negative_false_premise",
+    "question": "¿Qué cambio hizo la reforma de vacaciones dignas de diciembre de 2022 al artículo 123 de la Constitución?",
+    "persona": "trabajador",
+    "difficulty": "medium",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "No reformó el artículo 123 constitucional. Reformó los artículos 76 y 78 de la Ley Federal del Trabajo para establecer al menos doce días laborables de vacaciones y doce días continuos como mínimo.",
+    "unanswerable_reason": "wrong_legal_instrument",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 586299,
+        "publication_date": "2022-12-27",
+        "section": "VES",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "DECRETO por el que se reforman los artículos 76 y 78 de la Ley Federal del Trabajo, en materia de vacaciones."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-004",
+    "category": "negative_false_premise",
+    "question": "¿Por qué la UMA de 2026 comenzó a aplicarse el 1 de enero de 2026?",
+    "persona": "contador",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "No comenzó a aplicarse el 1 de enero. Los valores de la UMA 2026 estuvieron vigentes a partir del 1 de febrero de 2026.",
+    "unanswerable_reason": "wrong_effective_date",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 652586,
+        "publication_date": "2026-01-09",
+        "section": "MAT",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "el valor diario de la Unidad de Medida y Actualización es de $117.31 pesos mexicanos, el mensual es de $3,566.22 pesos mexicanos y el valor anual $42,794.64 pesos mexicanos, los cuales estarán vigentes a partir del 1º de febrero de 2026."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-005",
+    "category": "negative_false_premise",
+    "question": "¿Por qué los salarios mínimos de 2026 comenzaron a regir desde su publicación el 9 de diciembre de 2025?",
+    "persona": "recursos_humanos",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "No comenzaron a regir el día de publicación. La resolución dispuso que los salarios mínimos de 2026 tuvieran vigencia a partir del 1 de enero de 2026.",
+    "unanswerable_reason": "wrong_effective_date",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 651143,
+        "publication_date": "2025-12-09",
+        "section": "MAT",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "Los salarios mínimos generales que tendrán vigencia a partir del 1º de enero de 2026, reflejan un incremento de la siguiente manera."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NE-006",
+    "category": "negative_false_premise",
+    "question": "¿Qué 15 inmuebles integran las 50,000 m² expropiadas para el Tren Maya en abril de 2026?",
+    "persona": "periodista",
+    "difficulty": "easy",
+    "as_of": "2026-04-24",
+    "answerability": "false_premise",
+    "reference_answer": "La premisa tiene dos cifras incorrectas: el decreto comprende 14 inmuebles y una superficie de 48,661.703 m², no 15 inmuebles ni 50,000 m².",
+    "unanswerable_reason": "wrong_quantities",
+    "required_hops": 1,
+    "gold_documents": [
+      {
+        "document_id": 657317,
+        "publication_date": "2026-04-17",
+        "section": "MAT",
+        "role": "premise_refutation",
+        "evidence": [
+          {
+            "quote": "Se expropia por causa de utilidad pública la superficie de 48,661.703 m² (cuarenta y ocho mil seiscientos sesenta y uno punto setecientos tres metros cuadrados), a favor de la Federación, por conducto de Tren Maya, S.A. de C.V., para la ejecución de los tramos 1, 2, 3, 5 y 6 del Proyecto Tren Maya, correspondiente a 14 (catorce) inmuebles de propiedad privada."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -81,6 +81,36 @@ export function getStaticPaths() {
     </div>
   </section>
 
+  {
+    lang === 'es' && (
+      <aside class="evaluation-callout" aria-labelledby="eval-v4-callout-title">
+        <div class="evaluation-callout-heading">
+          <p>Revisión abierta</p>
+          <h2 id="eval-v4-callout-title">Ayúdanos a revisar Eval v4</h2>
+        </div>
+        <p class="evaluation-callout-copy">
+          Publicamos 42 preguntas con sus respuestas, fechas de corte y citas de
+          referencia. Puedes revisar una sola pregunta y señalar ambigüedades,
+          problemas de vigencia o fuentes alternativas.
+        </p>
+        <div class="evaluation-callout-actions">
+          <a
+            class="primary-action"
+            href={`${import.meta.env.BASE_URL}/es/evals/v4`}
+          >
+            Revisar las preguntas
+          </a>
+          <a
+            class="secondary-action"
+            href={`${import.meta.env.BASE_URL}/es/blog/2026/08/eval-v4-evidencia-retrieval`}
+          >
+            Leer el reporte <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </aside>
+    )
+  }
+
   <section
     id="research"
     class="research-section"
@@ -279,6 +309,47 @@ export function getStaticPaths() {
     text-align: right;
   }
 
+  .evaluation-callout {
+    display: grid;
+    grid-template-columns: minmax(14rem, 0.8fr) minmax(18rem, 1.35fr) auto;
+    gap: 2rem;
+    align-items: center;
+    margin: 0 0 3rem;
+    padding: 1.4rem 1.5rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+  }
+
+  .evaluation-callout-heading p {
+    margin: 0 0 0.35rem;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .evaluation-callout-heading h2 {
+    margin: 0;
+    font-size: clamp(1.55rem, 2.5vw, 2.15rem);
+    line-height: 1.05;
+  }
+
+  .evaluation-callout-copy {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    line-height: 1.6;
+  }
+
+  .evaluation-callout-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
   .research-section {
     scroll-margin-top: 7rem;
     border-top: 2px solid var(--color-text);
@@ -412,6 +483,18 @@ export function getStaticPaths() {
       border-top: 1px solid var(--color-border);
       border-left: 0;
       padding: 1rem 0 0;
+    }
+
+    .evaluation-callout {
+      grid-template-columns: 1fr;
+      gap: 1.15rem;
+      padding: 1.25rem;
+    }
+
+    .evaluation-callout-actions {
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 1rem;
     }
 
     .ledger-count {

--- a/src/pages/es/evals/v4.astro
+++ b/src/pages/es/evals/v4.astro
@@ -1,0 +1,692 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import questions from '../../../data/eval-v4-review.json';
+
+const categoryOrder = [
+  'single_passage',
+  'list_enumeration',
+  'temporal_transitorio',
+  'cross_reference',
+  'multi_document',
+  'monitoring',
+  'negative_false_premise',
+] as const;
+
+const categories = {
+  single_passage: {
+    label: 'Pasaje único',
+    description: 'Una respuesta concreta respaldada por un fragmento.',
+  },
+  list_enumeration: {
+    label: 'Listas completas',
+    description:
+      'Preguntas donde omitir un elemento vuelve incompleta la respuesta.',
+  },
+  temporal_transitorio: {
+    label: 'Vigencia y transitorios',
+    description: 'Fechas de entrada en vigor, plazos y obligaciones diferidas.',
+  },
+  cross_reference: {
+    label: 'Referencias cruzadas',
+    description:
+      'Artículos y numerales cuyo sentido depende de otra disposición.',
+  },
+  multi_document: {
+    label: 'Múltiples documentos',
+    description:
+      'Respuestas que necesitan reunir evidencia de dos o más publicaciones.',
+  },
+  monitoring: {
+    label: 'Monitoreo',
+    description: 'Publicaciones localizadas por institución, fecha o edición.',
+  },
+  negative_false_premise: {
+    label: 'Premisas falsas',
+    description: 'Preguntas que el sistema debe corregir en lugar de aceptar.',
+  },
+};
+
+const difficultyLabels = {
+  easy: 'básica',
+  medium: 'intermedia',
+  hard: 'difícil',
+};
+
+const discussionUrl =
+  'https://github.com/CodeandoGuadalajara/dof-rag/discussions';
+const datasetUrl =
+  'https://github.com/CodeandoGuadalajara/dof-rag/blob/main/eval/dof_queries_v4.jsonl';
+
+const documentCount = new Set(
+  questions.flatMap((question) =>
+    question.gold_documents.map((document) => document.document_id)
+  )
+).size;
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('es-MX', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function formatPersona(value: string): string {
+  return value.replaceAll('_', ' ');
+}
+
+function formatDifficulty(value: string): string {
+  return difficultyLabels[value as keyof typeof difficultyLabels] ?? value;
+}
+
+function feedbackUrl(questionId: string): string {
+  const url = new URL(
+    'https://github.com/CodeandoGuadalajara/dof-rag/issues/new'
+  );
+  url.searchParams.set('template', 'eval-v4-feedback.yml');
+  url.searchParams.set('title', `[Eval v4] ${questionId}: `);
+  return url.toString();
+}
+---
+
+<Layout
+  title="Revisión pública de Eval v4 | DOF-RAG"
+  description="Revisa las 42 preguntas, respuestas y citas de referencia de la evaluación de recuperación de evidencia de DOF-RAG."
+>
+  <article class="review-shell">
+    <header class="review-header">
+      <p class="kicker">Evaluación abierta · versión 4.0.0 piloto</p>
+      <h1>Revisión pública de Eval v4</h1>
+      <p class="lede">
+        Estas 42 preguntas sirven para medir si un buscador del Diario Oficial
+        encuentra la evidencia necesaria para responder, no solo un documento
+        relacionado. Publicamos las respuestas y citas de referencia para que
+        puedan ser revisadas antes de convertir el conjunto en una puerta de
+        calidad.
+      </p>
+
+      <dl class="review-summary" aria-label="Resumen del conjunto">
+        <div>
+          <dt>Preguntas</dt>
+          <dd>{questions.length}</dd>
+        </div>
+        <div>
+          <dt>Categorías</dt>
+          <dd>{categoryOrder.length}</dd>
+        </div>
+        <div>
+          <dt>Documentos</dt>
+          <dd>{documentCount}</dd>
+        </div>
+        <div>
+          <dt>Corte del corpus</dt>
+          <dd>24 abr 2026</dd>
+        </div>
+      </dl>
+
+      <div class="review-actions" aria-label="Acciones de revisión">
+        <a class="primary-action" href={discussionUrl}
+          >Discutir la metodología ↗</a
+        >
+        <a class="secondary-action" href={datasetUrl}>Consultar el dataset ↗</a>
+      </div>
+    </header>
+
+    <section class="review-guide" aria-labelledby="how-to-review">
+      <div>
+        <p class="section-number">Cómo participar</p>
+        <h2 id="how-to-review">Una observación concreta es suficiente</h2>
+      </div>
+      <div class="guide-copy">
+        <p>
+          No hace falta revisar las 42 preguntas. Elige una que conozcas y
+          comprueba cuatro cosas: que la pregunta sea clara, que la respuesta
+          sea correcta para su fecha de corte, que la cita realmente la respalde
+          y que no falte otra fuente válida.
+        </p>
+        <p>
+          Usa la discusión para comentarios generales sobre categorías o
+          metodología. Si encuentras un problema específico, abre el formulario
+          de esa pregunta; así podremos documentar la corrección y cerrarla.
+        </p>
+      </div>
+    </section>
+
+    <nav class="category-index" aria-label="Categorías de la evaluación">
+      {
+        categoryOrder.map((category) => (
+          <a href={`#${category}`}>
+            <span>{categories[category].label}</span>
+            <small>6 preguntas</small>
+          </a>
+        ))
+      }
+    </nav>
+
+    {
+      categoryOrder.map((category, categoryIndex) => {
+        const categoryQuestions = questions.filter(
+          (question) => question.category === category
+        );
+
+        return (
+          <section class="category-section" id={category}>
+            <header class="category-header">
+              <p class="section-number">
+                Categoría {String(categoryIndex + 1).padStart(2, '0')}
+              </p>
+              <h2>{categories[category].label}</h2>
+              <p>{categories[category].description}</p>
+            </header>
+
+            <div class="question-list">
+              {categoryQuestions.map((question) => (
+                <details class="question-card" id={question.id.toLowerCase()}>
+                  <summary>
+                    <span class="question-id">{question.id}</span>
+                    <span class="question-text">{question.question}</span>
+                    <span class="open-label" aria-hidden="true">
+                      Abrir
+                    </span>
+                  </summary>
+
+                  <div class="question-content">
+                    <dl class="question-meta">
+                      <div>
+                        <dt>Fecha de corte</dt>
+                        <dd>{formatDate(question.as_of)}</dd>
+                      </div>
+                      <div>
+                        <dt>Dificultad</dt>
+                        <dd>{formatDifficulty(question.difficulty)}</dd>
+                      </div>
+                      <div>
+                        <dt>Perfil de consulta</dt>
+                        <dd>{formatPersona(question.persona)}</dd>
+                      </div>
+                      <div>
+                        <dt>Fuentes necesarias</dt>
+                        <dd>{question.required_hops}</dd>
+                      </div>
+                    </dl>
+
+                    <section
+                      class="answer-block"
+                      aria-labelledby={`${question.id}-answer`}
+                    >
+                      <p class="content-label" id={`${question.id}-answer`}>
+                        Respuesta de referencia
+                      </p>
+                      <p>{question.reference_answer}</p>
+                    </section>
+
+                    {question.unanswerable_reason && (
+                      <section class="premise-block">
+                        <p class="content-label">
+                          Por qué se rechaza la premisa
+                        </p>
+                        <p>{question.unanswerable_reason}</p>
+                      </section>
+                    )}
+
+                    <section
+                      class="evidence-block"
+                      aria-labelledby={`${question.id}-evidence`}
+                    >
+                      <p class="content-label" id={`${question.id}-evidence`}>
+                        Evidencia de referencia
+                      </p>
+                      {question.gold_documents.map(
+                        (document, documentIndex) => (
+                          <div class="source-document">
+                            <p class="source-heading">
+                              Documento {documentIndex + 1} · DOF{' '}
+                              {formatDate(document.publication_date)}
+                              {' · '}sección {document.section} · ID{' '}
+                              {document.document_id}
+                            </p>
+                            {document.evidence.map((evidence) => (
+                              <blockquote>{evidence.quote}</blockquote>
+                            ))}
+                          </div>
+                        )
+                      )}
+                    </section>
+
+                    <a class="feedback-action" href={feedbackUrl(question.id)}>
+                      Informar un problema con {question.id} ↗
+                    </a>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </section>
+        );
+      })
+    }
+
+    <footer class="review-footer">
+      <p>
+        Eval v4 es un piloto. Las observaciones aceptadas quedarán registradas
+        en el historial del dataset; no cambiaremos silenciosamente una pregunta
+        después de usarla para comparar sistemas.
+      </p>
+      <a
+        href={`${import.meta.env.BASE_URL}/es/blog/2026/08/eval-v4-evidencia-retrieval`}
+      >
+        Leer el reporte de resultados →
+      </a>
+    </footer>
+  </article>
+</Layout>
+
+<style>
+  .review-shell {
+    max-width: 68rem;
+    margin: 0 auto;
+  }
+
+  .review-header {
+    max-width: 58rem;
+    padding: 3rem 0 4rem;
+  }
+
+  .kicker,
+  .section-number,
+  .content-label,
+  .question-id,
+  .review-summary dt {
+    margin: 0;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 750;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    max-width: 15ch;
+    margin: 1rem 0 1.5rem;
+    font-size: clamp(3rem, 8vw, 6.5rem);
+    line-height: 0.92;
+  }
+
+  .lede {
+    max-width: 48rem;
+    margin: 0;
+    color: var(--color-muted);
+    font-family: var(--font-editorial);
+    font-size: clamp(1.2rem, 2.4vw, 1.65rem);
+    line-height: 1.45;
+  }
+
+  .review-summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin: 3rem 0 0;
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .review-summary div {
+    padding: 1.1rem 1rem 1.1rem 0;
+  }
+
+  .review-summary div + div {
+    border-left: 1px solid var(--color-border);
+    padding-left: 1rem;
+  }
+
+  .review-summary dd {
+    margin: 0.35rem 0 0;
+    font-family: var(--font-editorial);
+    font-size: 1.45rem;
+    font-weight: 700;
+  }
+
+  .review-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .review-actions a,
+  .feedback-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.8rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--color-accent);
+    font-size: 0.78rem;
+    font-weight: 750;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+  }
+
+  .primary-action,
+  .feedback-action {
+    background: var(--color-accent);
+    color: #fffaf1;
+  }
+
+  .review-actions a:hover,
+  .feedback-action:hover {
+    background: var(--color-text);
+    border-color: var(--color-text);
+    color: var(--color-bg);
+  }
+
+  .review-guide {
+    display: grid;
+    grid-template-columns: minmax(15rem, 0.8fr) minmax(0, 1.5fr);
+    gap: 3rem;
+    margin-bottom: 3rem;
+    padding: 2.25rem;
+    background: var(--color-paper-deep);
+  }
+
+  .review-guide h2,
+  .category-header h2 {
+    margin: 0.45rem 0 0;
+    font-size: clamp(2rem, 4vw, 3.4rem);
+    line-height: 1;
+  }
+
+  .guide-copy p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  .guide-copy p + p {
+    margin-top: 1rem;
+  }
+
+  .category-index {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    margin-bottom: 5rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-border);
+  }
+
+  .category-index a {
+    display: flex;
+    min-height: 6.5rem;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 1rem;
+    background: var(--color-card);
+    text-decoration: none;
+  }
+
+  .category-index a:hover {
+    background: var(--color-paper-deep);
+    color: var(--color-accent);
+  }
+
+  .category-index span {
+    font-family: var(--font-editorial);
+    font-size: 1.15rem;
+    font-weight: 700;
+  }
+
+  .category-index small {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .category-section {
+    scroll-margin-top: 7rem;
+    margin: 0 0 6rem;
+  }
+
+  .category-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.75fr);
+    column-gap: 3rem;
+    align-items: end;
+    margin-bottom: 1.5rem;
+  }
+
+  .category-header .section-number,
+  .category-header h2 {
+    grid-column: 1;
+  }
+
+  .category-header > p:last-child {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    align-self: end;
+    margin: 0;
+    color: var(--color-muted);
+    line-height: 1.55;
+  }
+
+  .question-list {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .question-card {
+    scroll-margin-top: 7rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .question-card summary {
+    display: grid;
+    grid-template-columns: 5rem minmax(0, 1fr) auto;
+    gap: 1.25rem;
+    align-items: start;
+    padding: 1.35rem 0;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .question-card summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .question-card[open] summary {
+    color: var(--color-accent);
+  }
+
+  .question-text {
+    max-width: 48rem;
+    font-family: var(--font-editorial);
+    font-size: clamp(1.1rem, 2vw, 1.35rem);
+    font-weight: 650;
+    line-height: 1.35;
+  }
+
+  .open-label {
+    padding-top: 0.15rem;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .question-card[open] .open-label::before {
+    content: 'Cerrar';
+  }
+
+  .question-card[open] .open-label {
+    font-size: 0;
+  }
+
+  .question-card[open] .open-label::before {
+    font-size: 0.68rem;
+  }
+
+  .question-content {
+    margin: 0 0 1.5rem 6.25rem;
+    padding: 1.5rem;
+    border-left: 3px solid var(--color-accent);
+    background: var(--color-card);
+  }
+
+  .question-meta {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin: 0 0 1.75rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .question-meta dt {
+    color: var(--color-muted);
+    font-size: 0.68rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .question-meta dd {
+    margin: 0.3rem 0 0;
+    font-size: 0.9rem;
+    font-weight: 650;
+  }
+
+  .answer-block,
+  .premise-block,
+  .evidence-block {
+    max-width: 50rem;
+  }
+
+  .answer-block > p:last-child,
+  .premise-block > p:last-child {
+    margin: 0.45rem 0 0;
+    font-family: var(--font-editorial);
+    font-size: 1.15rem;
+    line-height: 1.55;
+  }
+
+  .premise-block,
+  .evidence-block {
+    margin-top: 1.75rem;
+  }
+
+  .source-document {
+    margin-top: 0.8rem;
+  }
+
+  .source-heading {
+    margin: 0;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    line-height: 1.5;
+  }
+
+  blockquote {
+    margin: 0.75rem 0 0;
+    padding: 0.85rem 1rem;
+    border-left: 1px solid var(--color-border);
+    color: var(--color-muted);
+    font-family: var(--font-editorial);
+    font-size: 0.98rem;
+    line-height: 1.6;
+  }
+
+  .feedback-action {
+    margin-top: 1.75rem;
+  }
+
+  .review-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 3rem;
+    align-items: flex-end;
+    margin-top: 2rem;
+    padding: 2.25rem 0 1rem;
+    border-top: 2px solid var(--color-text);
+  }
+
+  .review-footer p {
+    max-width: 42rem;
+    margin: 0;
+    line-height: 1.65;
+  }
+
+  .review-footer a {
+    flex: none;
+    color: var(--color-accent);
+    font-weight: 750;
+  }
+
+  @media (max-width: 760px) {
+    .review-header {
+      padding-top: 1.5rem;
+    }
+
+    .review-summary,
+    .category-index {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .review-summary div:nth-child(3) {
+      border-left: 0;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .review-summary div:nth-child(4) {
+      border-top: 1px solid var(--color-border);
+    }
+
+    .review-guide,
+    .category-header {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .category-header > p:last-child {
+      grid-column: 1;
+      grid-row: auto;
+    }
+
+    .question-card summary {
+      grid-template-columns: 4rem minmax(0, 1fr);
+      gap: 0.75rem;
+    }
+
+    .open-label {
+      display: none;
+    }
+
+    .question-content {
+      margin-left: 0;
+      padding: 1.25rem;
+    }
+
+    .question-meta {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .review-footer {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+
+  @media (max-width: 430px) {
+    .review-summary,
+    .category-index,
+    .question-meta {
+      grid-template-columns: 1fr;
+    }
+
+    .review-summary div + div,
+    .review-summary div:nth-child(3) {
+      border-top: 1px solid var(--color-border);
+      border-left: 0;
+      padding-left: 0;
+    }
+  }
+</style>

--- a/src/pages/es/evals/v4.astro
+++ b/src/pages/es/evals/v4.astro
@@ -122,11 +122,11 @@ function feedbackUrl(questionId: string): string {
         encuentra la evidencia necesaria para responder, no solo un documento
         relacionado. Publicamos las respuestas y citas de referencia para que
         puedan ser revisadas antes de convertir el conjunto en una puerta de
-        calidad. El
+        calidad. El{' '}
         <a
           href={`${import.meta.env.BASE_URL}/es/blog/2026/08/eval-v4-evidencia-retrieval`}
           >reporte de Eval v4</a
-        >
+        >{' '}
         explica cómo construimos el conjunto y qué ocurrió al probar búsqueda BM25,
         vectorial e híbrida.
       </p>
@@ -351,8 +351,16 @@ function feedbackUrl(questionId: string): string {
 
   .lede a {
     color: var(--color-accent);
-    text-decoration-thickness: 1px;
-    text-underline-offset: 0.15em;
+    font-weight: 700;
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-accent-light);
+    text-decoration-thickness: 0.08em;
+    text-underline-offset: 0.18em;
+  }
+
+  .lede a:hover {
+    color: var(--color-text);
+    text-decoration-color: var(--color-accent);
   }
 
   .review-summary {

--- a/src/pages/es/evals/v4.astro
+++ b/src/pages/es/evals/v4.astro
@@ -52,6 +52,18 @@ const difficultyLabels = {
   hard: 'difícil',
 };
 
+const premiseReasonLabels = {
+  nonexistent_article: 'La publicación no contiene el artículo mencionado.',
+  incorrect_abrogation_claim:
+    'El decreto no abroga por completo la ley en la forma planteada.',
+  wrong_legal_instrument:
+    'La pregunta atribuye el cambio a un instrumento jurídico distinto.',
+  wrong_effective_date:
+    'La fecha de entrada en vigor propuesta en la pregunta es incorrecta.',
+  wrong_quantities:
+    'Las cantidades de la pregunta no coinciden con la publicación.',
+};
+
 const discussionUrl =
   'https://github.com/CodeandoGuadalajara/dof-rag/discussions';
 const datasetUrl =
@@ -78,6 +90,13 @@ function formatPersona(value: string): string {
 
 function formatDifficulty(value: string): string {
   return difficultyLabels[value as keyof typeof difficultyLabels] ?? value;
+}
+
+function formatPremiseReason(value: string): string {
+  return (
+    premiseReasonLabels[value as keyof typeof premiseReasonLabels] ??
+    value.replaceAll('_', ' ')
+  );
 }
 
 function feedbackUrl(questionId: string): string {
@@ -226,7 +245,9 @@ function feedbackUrl(questionId: string): string {
                         <p class="content-label">
                           Por qué se rechaza la premisa
                         </p>
-                        <p>{question.unanswerable_reason}</p>
+                        <p>
+                          {formatPremiseReason(question.unanswerable_reason)}
+                        </p>
                       </section>
                     )}
 

--- a/src/pages/es/evals/v4.astro
+++ b/src/pages/es/evals/v4.astro
@@ -122,7 +122,13 @@ function feedbackUrl(questionId: string): string {
         encuentra la evidencia necesaria para responder, no solo un documento
         relacionado. Publicamos las respuestas y citas de referencia para que
         puedan ser revisadas antes de convertir el conjunto en una puerta de
-        calidad.
+        calidad. El
+        <a
+          href={`${import.meta.env.BASE_URL}/es/blog/2026/08/eval-v4-evidencia-retrieval`}
+          >reporte de Eval v4</a
+        >
+        explica cómo construimos el conjunto y qué ocurrió al probar búsqueda BM25,
+        vectorial e híbrida.
       </p>
 
       <dl class="review-summary" aria-label="Resumen del conjunto">
@@ -341,6 +347,12 @@ function feedbackUrl(questionId: string): string {
     font-family: var(--font-editorial);
     font-size: clamp(1.2rem, 2.4vw, 1.65rem);
     line-height: 1.45;
+  }
+
+  .lede a {
+    color: var(--color-accent);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.15em;
   }
 
   .review-summary {


### PR DESCRIPTION
## Qué cambia

Añade una edición pública y legible de Eval v4 en:

`/es/evals/v4`

La página:

- presenta las 42 preguntas agrupadas en siete categorías;
- mantiene las fichas cerradas para facilitar el recorrido;
- muestra bajo demanda la respuesta, fecha de corte y evidencia citada;
- enlaza cada pregunta a un formulario de corrección con su ID en el título;
- dirige los comentarios metodológicos a GitHub Discussions;
- enlaza el dataset fuente y el reporte de resultados.

También añade:

- un llamado visible en la página de inicio en español;
- un enlace al reporte dentro de la introducción de la página de revisión;
- una invitación a participar al final del artículo de Eval v4.

## Por qué

El artículo explica la metodología y los resultados, pero no ofrece una superficie práctica para revisar 42 preguntas. Esta página permite que una persona revise una sola pregunta sin leer JSONL ni navegar por archivos internos.

## Dependencia

El dataset y el formulario de feedback se publican en [dof-rag#65](https://github.com/CodeandoGuadalajara/dof-rag/pull/65). Conviene fusionar ese PR primero para que los enlaces al dataset y al formulario estén disponibles cuando se despliegue esta página.

## Validación

- `pnpm run check`: 0 errores; solo 19 hints preexistentes.
- `pnpm run build`: 139 páginas, incluida `/es/evals/v4`.
- Validadas 42 fichas y 42 enlaces de feedback.
- Revisión visual en escritorio y a 390 px, sin desbordamiento horizontal.
- Llamado de la página de inicio verificado en escritorio y móvil.
- Tarjetas expandidas verificadas con respuestas y citas largas.
- Sin errores en la consola del navegador.
- Prettier y `git diff --cached --check`.
